### PR TITLE
Update s2n-tls specfile to successfully build

### DIFF
--- a/specs/s2n-tls.spec
+++ b/specs/s2n-tls.spec
@@ -7,6 +7,7 @@ License:        ASL-2.0
 URL:            https://github.com/davdunc/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
+BuildRequires: gcc
 BuildRequires: cmake
 BuildRequires: openssl-devel
 BuildRequires: ninja-build
@@ -21,14 +22,16 @@ designed to be simple, small, fast, and with security as a priority.
 
 
 %build
-%cmake
+%cmake -DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF -DBUILD_SHARED_LIBS=ON
 %cmake_build
 
 %install
 %cmake_install
-
+rm -rf %{buildroot}%{_libdir}/s2n
 
 %files
+%{_includedir}/s2n.h
+%{_libdir}/libs2n.so
 %license LICENSE
 %doc VERSIONING.rst NOTICE README.md
 %doc docs/READING-LIST.md docs/USAGE-GUIDE.md


### PR DESCRIPTION
This now builds successfully with `rpmbuild` and `mock`. It required the following changes to build:

* Require `gcc` as the compiler to build
* Turn off configuration for treating compilation warnings as errors. This is to work around this issue: https://github.com/aws/s2n-tls/issues/2989 where s2n cannot be built using gcc 11
* Build s2n as a shared library to conform with Fedora best practices
* Remove `.cmake` files that are left from the build by deleting the `s2n` directory
* Add the header and so file for s2n to the files installed by the rpm