### PR TITLE
Add aws-c-common specfile

### DIFF
--- a/specs/aws-c-common.spec
+++ b/specs/aws-c-common.spec
@@ -2,6 +2,7 @@ Name:           aws-c-common
 Version:        0.6.14 
 Release:        1%{?dist}
 Summary:        Core c99 package for AWS SDK for C
+Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
@@ -11,6 +12,24 @@ BuildRequires:  gcc
 BuildRequires:  cmake
 
 %description
+Core c99 package for AWS SDK for C. Includes cross-platform primitives,
+configuration, data structures, and error handling.
+
+
+%package libs
+Summary:        Core c99 package for AWS SDK for C
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description libs
+Core c99 package for AWS SDK for C. Includes cross-platform primitives,
+configuration, data structures, and error handling.
+
+
+%package devel
+Summary:        Core c99 package for AWS SDK for C
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description devel
 Core c99 package for AWS SDK for C. Includes cross-platform primitives,
 configuration, data structures, and error handling.
 
@@ -31,6 +50,12 @@ configuration, data structures, and error handling.
 %license LICENSE
 %doc README.md
 
+%files libs
+%{_libdir}/libaws-c-common.so
+%{_libdir}/libaws-c-common.so.1
+%{_libdir}/libaws-c-common.so.1.0.0
+
+%files devel
 %{_includedir}/aws/common/*.h
 %{_includedir}/aws/common/*.inl
 %{_includedir}/aws/common/posix/common.inl
@@ -48,10 +73,6 @@ configuration, data structures, and error handling.
 %{_libdir}/cmake/AwsSanitizers.cmake
 %{_libdir}/cmake/AwsSharedLibSetup.cmake
 %{_libdir}/cmake/AwsTestHarness.cmake
-
-%{_libdir}/libaws-c-common.so
-%{_libdir}/libaws-c-common.so.1
-%{_libdir}/libaws-c-common.so.1.0.0
 
 
 %changelog

--- a/specs/aws-c-common.spec
+++ b/specs/aws-c-common.spec
@@ -1,0 +1,59 @@
+Name:           aws-c-common
+Version:        0.6.14 
+Release:        1%{?dist}
+Summary:        Core c99 package for AWS SDK for C
+
+License:        ASL-2.0
+URL:            https://github.com/awslabs/%{name}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  cmake
+
+%description
+Core c99 package for AWS SDK for C. Includes cross-platform primitives,
+configuration, data structures, and error handling.
+
+
+%prep
+%autosetup
+
+
+%build
+%cmake -DBUILD_SHARED_LIBS=ON
+%cmake_build
+
+%install
+%cmake_install
+
+
+%files
+%license LICENSE
+%doc README.md
+
+%{_includedir}/aws/common/*.h
+%{_includedir}/aws/common/*.inl
+%{_includedir}/aws/common/posix/common.inl
+%{_includedir}/aws/testing/aws_test_harness.h
+
+%{_libdir}/aws-c-common/cmake/aws-c-common-config.cmake
+%{_libdir}/aws-c-common/cmake/shared/aws-c-common-targets-noconfig.cmake
+%{_libdir}/aws-c-common/cmake/shared/aws-c-common-targets.cmake
+%{_libdir}/cmake/AwsCFlags.cmake
+%{_libdir}/cmake/AwsCheckHeaders.cmake
+%{_libdir}/cmake/AwsFeatureTests.cmake
+%{_libdir}/cmake/AwsFindPackage.cmake
+%{_libdir}/cmake/AwsLibFuzzer.cmake
+%{_libdir}/cmake/AwsSIMD.cmake
+%{_libdir}/cmake/AwsSanitizers.cmake
+%{_libdir}/cmake/AwsSharedLibSetup.cmake
+%{_libdir}/cmake/AwsTestHarness.cmake
+
+%{_libdir}/libaws-c-common.so
+%{_libdir}/libaws-c-common.so.1
+%{_libdir}/libaws-c-common.so.1.0.0
+
+
+%changelog
+* Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>
+- 


### PR DESCRIPTION
This is the first of many specfiles to build out the modules of aws-crt dependency. The `aws-c-common` is the first module and it has no dependencies. I split the package into a `libs` and `devel` packages as well.