### PR TITLE
Add specfiles for the rest of the CRT modules

### DIFF
--- a/specs/aws-c-auth.spec
+++ b/specs/aws-c-auth.spec
@@ -1,0 +1,83 @@
+Name:           aws-c-auth
+Version:        0.6.5 
+Release:        1%{?dist}
+Summary:        C99 library implementation of AWS client-side authentication
+Epoch:          1
+
+License:        ASL-2.0
+URL:            https://github.com/awslabs/%{name}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  cmake
+BuildRequires:  openssl-devel
+BuildRequires:  aws-c-common-devel = 1:0.6.14
+BuildRequires:  aws-c-sdkutils-devel = 1:0.1.1
+BuildRequires:  aws-c-cal-devel = 1:0.5.12
+BuildRequires:  aws-c-io-devel = 1:0.10.12
+BuildRequires:  aws-c-compression-devel = 1:0.2.14
+BuildRequires:  aws-c-http-devel = 1:0.6.8
+
+Requires:       openssl
+Requires:       aws-c-common-libs = 1:0.6.14
+Requires:       aws-c-sdkutils-libs = 1:0.1.1
+Requires:       aws-c-cal-libs = 1:0.5.12
+Requires:       aws-c-io-libs = 1:0.10.12
+Requires:       aws-c-compression-libs = 1:0.2.14
+Requires:       aws-c-http-libs = 1:0.6.8
+
+%description
+C99 library implementation of AWS client-side authentication:
+standard credentials providers and signing
+
+
+%package libs
+Summary:        C99 library implementation of AWS client-side authentication
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description libs
+C99 library implementation of AWS client-side authentication:
+standard credentials providers and signing
+
+
+%package devel
+Summary:        C99 library implementation of AWS client-side authentication
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description devel
+C99 library implementation of AWS client-side authentication:
+standard credentials providers and signing
+
+
+%prep
+%autosetup
+
+
+%build
+%cmake -DBUILD_SHARED_LIBS=ON
+%cmake_build
+
+%install
+%cmake_install
+
+
+%files
+%license LICENSE
+%doc README.md
+
+%files libs
+%{_libdir}/libaws-c-auth.so
+%{_libdir}/libaws-c-auth.so.1.0.0
+
+%files devel
+%{_includedir}/aws/auth/*.h
+
+%{_libdir}/aws-c-auth/cmake/aws-c-auth-config.cmake
+%{_libdir}/aws-c-auth/cmake/shared/aws-c-auth-targets-noconfig.cmake
+%{_libdir}/aws-c-auth/cmake/shared/aws-c-auth-targets.cmake
+
+
+
+%changelog
+* Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>
+- 

--- a/specs/aws-c-cal.spec
+++ b/specs/aws-c-cal.spec
@@ -1,0 +1,75 @@
+Name:           aws-c-cal
+Version:        0.5.12 
+Release:        1%{?dist}
+Summary:        AWS Crypto Abstraction Layer
+Epoch:          1
+
+License:        ASL-2.0
+URL:            https://github.com/awslabs/%{name}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  cmake
+BuildRequires:  aws-c-common-devel = 1:0.6.14
+BuildRequires:  openssl-devel
+
+Requires:       aws-c-common-libs = 1:0.6.14
+Requires:       openssl
+
+%description
+AWS Crypto Abstraction Layer: Cross-Platform, C99 wrapper for
+cryptography primitives
+
+
+%package libs
+Summary:        AWS Crypto Abstraction Layer
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+	
+%description libs
+AWS Crypto Abstraction Layer: Cross-Platform, C99 wrapper for
+cryptography primitives
+
+
+%package devel
+Summary:        AWS Crypto Abstraction Layer
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description devel
+AWS Crypto Abstraction Layer: Cross-Platform, C99 wrapper for
+cryptography primitives
+
+
+%prep
+%autosetup
+
+
+%build
+%cmake -DBUILD_SHARED_LIBS=ON
+%cmake_build
+
+%install
+%cmake_install
+
+
+%files
+%license LICENSE
+%doc README.md
+
+%{_bindir}/sha256_profile
+
+%files libs
+%{_libdir}/libaws-c-cal.so
+%{_libdir}/libaws-c-cal.so.1.0.0
+
+%files devel
+%{_includedir}/aws/cal/*.h
+
+%{_libdir}/aws-c-cal/cmake/aws-c-cal-config.cmake
+%{_libdir}/aws-c-cal/cmake/modules/FindLibCrypto.cmake
+%{_libdir}/aws-c-cal/cmake/shared/aws-c-cal-targets-noconfig.cmake
+%{_libdir}/aws-c-cal/cmake/shared/aws-c-cal-targets.cmake
+
+
+%changelog
+* Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>
+- 

--- a/specs/aws-c-compression.spec
+++ b/specs/aws-c-compression.spec
@@ -1,0 +1,70 @@
+Name:           aws-c-compression
+Version:        0.2.14
+Release:        1%{?dist}
+Summary:        Compression package for AWS SDK for C
+Epoch:          1
+
+License:        ASL-2.0
+URL:            https://github.com/awslabs/%{name}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  cmake
+BuildRequires:  aws-c-common-devel = 1:0.6.14
+
+Requires:       aws-c-common-libs = 1:0.6.14
+
+%description
+This is a cross-platform C99 implementation of
+compression algorithms such as gzip, and huffman encoding/decoding.
+
+
+%package libs
+Summary:        Compression package for AWS SDK for C
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+	
+%description libs
+This is a cross-platform C99 implementation of
+compression algorithms such as gzip, and huffman encoding/decoding.
+
+
+%package devel
+Summary:        Compression package for AWS SDK for C
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description devel
+This is a cross-platform C99 implementation of
+compression algorithms such as gzip, and huffman encoding/decoding.
+
+
+%prep
+%autosetup
+
+
+%build
+%cmake -DBUILD_SHARED_LIBS=ON
+%cmake_build
+
+%install
+%cmake_install
+
+
+%files
+%license LICENSE
+%doc README.md
+
+%files libs
+%{_libdir}/libaws-c-compression.so
+%{_libdir}/libaws-c-compression.so.1.0.0
+
+%files devel
+%{_includedir}/aws/compression/*.h
+
+%{_libdir}/aws-c-compression/cmake/aws-c-compression-config.cmake
+%{_libdir}/aws-c-compression/cmake/shared/aws-c-compression-targets-noconfig.cmake
+%{_libdir}/aws-c-compression/cmake/shared/aws-c-compression-targets.cmake
+
+
+%changelog
+* Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>
+- 

--- a/specs/aws-c-event-stream.spec
+++ b/specs/aws-c-event-stream.spec
@@ -1,0 +1,71 @@
+Name:           aws-c-event-stream
+Version:        0.2.7 
+Release:        1%{?dist}
+Summary:        C99 implementation of the vnd.amazon.eventstream content-type
+Epoch:          1
+
+License:        ASL-2.0
+URL:            https://github.com/awslabs/%{name}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  cmake
+BuildRequires:  aws-c-common-devel = 1:0.6.14
+BuildRequires:  aws-checksums-devel = 1:0.1.12
+BuildRequires:  aws-c-io-devel = 1:0.10.12
+
+Requires:       aws-c-common-libs = 1:0.6.14
+Requires:       aws-checksums-libs = 1:0.1.12
+Requires:       aws-c-io-libs = 1:0.10.12
+
+%description
+C99 implementation of the vnd.amazon.eventstream content-type
+
+
+%package libs
+Summary:        C99 implementation of the vnd.amazon.eventstream content-type
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description libs
+C99 implementation of the vnd.amazon.eventstream content-type
+
+
+%package devel
+Summary:        C99 implementation of the vnd.amazon.eventstream content-type
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description devel
+C99 implementation of the vnd.amazon.eventstream content-type
+
+
+%prep
+%autosetup
+
+
+%build
+%cmake -DBUILD_SHARED_LIBS=ON
+%cmake_build
+
+%install
+%cmake_install
+
+
+%files
+%license LICENSE
+%doc README.md
+
+%files libs
+%{_libdir}/libaws-c-event-stream.so
+%{_libdir}/libaws-c-event-stream.so.1.0.0
+
+%files devel
+%{_includedir}/aws/event-stream/*.h
+
+%{_libdir}/aws-c-event-stream/cmake/aws-c-event-stream-config.cmake
+%{_libdir}/aws-c-event-stream/cmake/shared/aws-c-event-stream-targets-noconfig.cmake
+%{_libdir}/aws-c-event-stream/cmake/shared/aws-c-event-stream-targets.cmake
+
+
+%changelog
+* Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>
+- 

--- a/specs/aws-c-http.spec
+++ b/specs/aws-c-http.spec
@@ -1,0 +1,73 @@
+Name:           aws-c-http
+Version:        0.6.8 
+Release:        1%{?dist}
+Summary:        C99 implementation of the HTTP/1.1 and HTTP/2 specifications
+Epoch:          1
+
+License:        ASL-2.0
+URL:            https://github.com/awslabs/%{name}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  cmake
+BuildRequires:  aws-c-common-devel = 1:0.6.14
+BuildRequires:  aws-c-compression-devel = 1:0.2.14
+BuildRequires:  aws-c-io-devel = 1:0.10.12
+
+Requires:       aws-c-common-libs = 1:0.6.14
+Requires:       aws-c-compression-libs = 1:0.2.14
+Requires:       aws-c-io-libs = 1:0.10.12
+
+%description
+C99 implementation of the HTTP/1.1 and HTTP/2 specifications
+
+
+%package libs
+Summary:        C99 implementation of the HTTP/1.1 and HTTP/2 specifications
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description libs
+C99 implementation of the HTTP/1.1 and HTTP/2 specifications
+
+
+%package devel
+Summary:        C99 implementation of the HTTP/1.1 and HTTP/2 specifications
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description devel
+C99 implementation of the HTTP/1.1 and HTTP/2 specifications
+
+
+%prep
+%autosetup
+
+
+%build
+%cmake -DBUILD_SHARED_LIBS=ON
+%cmake_build
+
+%install
+%cmake_install
+
+
+%files
+%license LICENSE
+%doc README.md
+
+%{_bindir}/elasticurl
+
+%files libs
+%{_libdir}/libaws-c-http.so
+%{_libdir}/libaws-c-http.so.1.0.0
+
+%files devel
+%{_includedir}/aws/http/*.h
+
+%{_libdir}/aws-c-http/cmake/aws-c-http-config.cmake
+%{_libdir}/aws-c-http/cmake/shared/aws-c-http-targets-noconfig.cmake
+%{_libdir}/aws-c-http/cmake/shared/aws-c-http-targets.cmake
+
+
+%changelog
+* Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>
+- 

--- a/specs/aws-c-io.spec
+++ b/specs/aws-c-io.spec
@@ -1,0 +1,77 @@
+Name:           aws-c-io
+Version:        0.10.12 
+Release:        1%{?dist}
+Summary:        IO package for AWS SDK for C
+Epoch:          1
+
+License:        ASL-2.0
+URL:            https://github.com/awslabs/%{name}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  cmake
+BuildRequires:  s2n-tls-devel
+BuildRequires:  aws-c-common-devel = 1:0.6.14
+BuildRequires:  aws-c-cal-devel = 1:0.5.12
+
+Requires:       s2n-tls-libs
+Requires:       aws-c-common-libs = 1:0.6.14
+Requires:       aws-c-cal-libs = 1:0.5.12
+
+%description
+IO package for AWS SDK for C. It handles all IO and TLS work
+for application protocols.
+
+
+%package libs
+Summary:        IO package for AWS SDK for C
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+	
+%description libs
+IO package for AWS SDK for C. It handles all IO and TLS work
+for application protocols.
+
+
+%package devel
+Summary:        IO package for AWS SDK for C
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       s2n-tls-devel
+Requires:       aws-c-cal-devel = 1:0.5.12
+
+%description devel
+IO package for AWS SDK for C. It handles all IO and TLS work
+for application protocols.
+
+
+%prep
+%autosetup
+
+
+%build
+%cmake -DBUILD_SHARED_LIBS=ON
+%cmake_build
+
+%install
+%cmake_install
+
+
+%files
+%license LICENSE
+%doc README.md
+
+%files libs
+%{_libdir}/libaws-c-io.so
+%{_libdir}/libaws-c-io.so.1.0.0
+
+%files devel
+%{_includedir}/aws/io/*.h
+%{_includedir}/aws/testing/io_testing_channel.h
+
+%{_libdir}/aws-c-io/cmake/aws-c-io-config.cmake
+%{_libdir}/aws-c-io/cmake/shared/aws-c-io-targets-noconfig.cmake
+%{_libdir}/aws-c-io/cmake/shared/aws-c-io-targets.cmake
+
+
+%changelog
+* Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>
+- 

--- a/specs/aws-c-mqtt.spec
+++ b/specs/aws-c-mqtt.spec
@@ -1,0 +1,81 @@
+Name:           aws-c-mqtt
+Version:        0.7.8
+Release:        1%{?dist}
+Summary:        C99 implementation of the MQTT 3.1.1 specification
+Epoch:          1
+
+License:        ASL-2.0
+URL:            https://github.com/awslabs/%{name}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  cmake
+BuildRequires:  openssl-devel
+BuildRequires:  aws-c-common-devel = 1:0.6.14
+BuildRequires:  aws-c-cal-devel = 1:0.5.12
+BuildRequires:  aws-c-io-devel = 1:0.10.12
+BuildRequires:  aws-c-compression-devel = 1:0.2.14
+BuildRequires:  aws-c-http-devel = 1:0.6.8
+
+Requires:       openssl-devel
+Requires:       aws-c-common-libs = 1:0.6.14
+Requires:       aws-c-cal-libs = 1:0.5.12
+Requires:       aws-c-io-libs = 1:0.10.12
+Requires:       aws-c-compression-libs = 1:0.2.14
+Requires:       aws-c-http-libs = 1:0.6.8
+
+%description
+C99 implementation of the MQTT 3.1.1 specification
+
+
+%package libs
+Summary:        C99 implementation of the MQTT 3.1.1 specification
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description libs
+C99 implementation of the MQTT 3.1.1 specification
+
+
+%package devel
+Summary:        C99 implementation of the MQTT 3.1.1 specification
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description devel
+C99 implementation of the MQTT 3.1.1 specification
+
+
+%prep
+%autosetup
+
+
+%build
+%cmake -DBUILD_SHARED_LIBS=ON
+%cmake_build
+
+%install
+%cmake_install
+
+
+%files
+%license LICENSE
+%doc README.md
+
+%{_bindir}/elastipubsub
+
+%files libs
+%{_libdir}/libaws-c-mqtt.so
+%{_libdir}/libaws-c-mqtt.so.1.0.0
+
+%files devel
+%{_includedir}/aws/mqtt/*.h
+%{_includedir}/aws/mqtt/private/mqtt_client_test_helper.h
+
+%{_libdir}/aws-c-mqtt/cmake/aws-c-mqtt-config.cmake
+%{_libdir}/aws-c-mqtt/cmake/shared/aws-c-mqtt-targets-noconfig.cmake
+%{_libdir}/aws-c-mqtt/cmake/shared/aws-c-mqtt-targets.cmake
+
+
+
+%changelog
+* Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>
+- 

--- a/specs/aws-c-s3.spec
+++ b/specs/aws-c-s3.spec
@@ -1,0 +1,83 @@
+Name:           aws-c-s3
+Version:        0.1.27
+Release:        1%{?dist}
+Summary:        C99 library implementation for communicating with the S3 service
+Epoch:          1
+
+License:        ASL-2.0
+URL:            https://github.com/awslabs/%{name}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  cmake
+BuildRequires:  aws-c-common-devel = 1:0.6.14
+BuildRequires:  aws-c-sdkutils-devel = 1:0.1.1
+BuildRequires:  aws-c-cal-devel = 1:0.5.12
+BuildRequires:  aws-c-compression-devel = 1:0.2.14
+BuildRequires:  aws-c-io-devel = 1:0.10.12
+BuildRequires:  aws-c-http-devel = 1:0.6.8
+BuildRequires:  aws-c-auth-devel = 1:0.6.5
+
+Requires:       aws-c-common-libs = 1:0.6.14
+Requires:       aws-c-sdkutils-libs = 1:0.1.1
+Requires:       aws-c-cal-libs = 1:0.5.12
+Requires:       aws-c-compression-libs = 1:0.2.14
+Requires:       aws-c-io-libs = 1:0.10.12
+Requires:       aws-c-http-libs = 1:0.6.8
+Requires:       aws-c-auth-libs = 1:0.6.5
+
+%description
+C99 library implementation for communicating with the S3 service,
+designed for maximizing throughput on high bandwidth EC2 instances.
+
+%package libs
+Summary:        C99 library implementation for communicating with the S3 service
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description libs
+C99 library implementation for communicating with the S3 service,
+designed for maximizing throughput on high bandwidth EC2 instances.
+
+
+%package devel
+Summary:        C99 library implementation for communicating with the S3 service
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description devel
+C99 library implementation for communicating with the S3 service,
+designed for maximizing throughput on high bandwidth EC2 instances.
+
+
+%prep
+%autosetup
+
+
+%build
+%cmake -DBUILD_SHARED_LIBS=ON
+%cmake_build
+
+%install
+%cmake_install
+
+
+%files
+%license LICENSE
+%doc README.md
+
+%files libs
+%{_libdir}/libaws-c-s3.so
+%{_libdir}/libaws-c-s3.so.0unstable
+%{_libdir}/libaws-c-s3.so.1.0.0
+
+%files devel
+%{_includedir}/aws/s3/*.h
+
+%{_libdir}/aws-c-s3/cmake/aws-c-s3-config.cmake
+%{_libdir}/aws-c-s3/cmake/shared/aws-c-s3-targets-noconfig.cmake
+%{_libdir}/aws-c-s3/cmake/shared/aws-c-s3-targets.cmake
+
+
+
+%changelog
+* Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>
+- 

--- a/specs/aws-c-sdkutils.spec
+++ b/specs/aws-c-sdkutils.spec
@@ -1,0 +1,67 @@
+Name:           aws-c-sdkutils
+Version:        0.1.1 
+Release:        1%{?dist}
+Summary:        Utility package for AWS SDK for C
+Epoch:          1
+
+License:        ASL-2.0
+URL:            https://github.com/awslabs/%{name}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  cmake
+BuildRequires:  aws-c-common-devel
+
+Requires:       aws-c-common-libs
+
+%description
+Utility package for AWS SDK for C
+
+
+%package libs
+Summary:        Utility package for AWS SDK for C
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+	
+%description libs
+Utility package for AWS SDK for C
+
+
+%package devel
+Summary:        Utility package for AWS SDK for C
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description devel
+Utility package for AWS SDK for C
+
+
+%prep
+%autosetup
+
+
+%build
+%cmake -DBUILD_SHARED_LIBS=ON
+%cmake_build
+
+%install
+%cmake_install
+
+
+%files
+%license LICENSE
+%doc README.md
+
+%files libs
+%{_libdir}/libaws-c-sdkutils.so
+%{_libdir}/libaws-c-sdkutils.so.1.0.0
+
+%files devel
+%{_includedir}/aws/sdkutils/*.h
+
+%{_libdir}/aws-c-sdkutils/cmake/aws-c-sdkutils-config.cmake
+%{_libdir}/aws-c-sdkutils/cmake/shared/aws-c-sdkutils-targets-noconfig.cmake
+%{_libdir}/aws-c-sdkutils/cmake/shared/aws-c-sdkutils-targets.cmake
+
+
+%changelog
+* Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>
+- 

--- a/specs/aws-c-sdkutils.spec
+++ b/specs/aws-c-sdkutils.spec
@@ -10,9 +10,9 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc
 BuildRequires:  cmake
-BuildRequires:  aws-c-common-devel
+BuildRequires:  aws-c-common-devel = 1:0.6.14
 
-Requires:       aws-c-common-libs
+Requires:       aws-c-common-libs = 1:0.6.14
 
 %description
 Utility package for AWS SDK for C

--- a/specs/aws-checksums.spec
+++ b/specs/aws-checksums.spec
@@ -1,0 +1,73 @@
+Name:           aws-checksums
+Version:        0.1.12 
+Release:        1%{?dist}
+Summary:        Checksum package for AWS SDK for C
+Epoch:          1
+
+License:        ASL-2.0
+URL:            https://github.com/awslabs/%{name}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  cmake
+BuildRequires:  aws-c-common-devel = 1:0.6.14
+
+Requires:       aws-c-common-libs = 1:0.6.14
+
+%description
+Checksum package for AWS SDK for C. Contains
+Cross-Platform HW accelerated CRC32c and CRC32 with
+fallback to efficient SW implementations.
+
+
+%package libs
+Summary:        Checksum package for AWS SDK for C
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+	
+%description libs
+Checksum package for AWS SDK for C. Contains
+Cross-Platform HW accelerated CRC32c and CRC32 with
+fallback to efficient SW implementations.
+
+
+%package devel
+Summary:        Checksum package for AWS SDK for C
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description devel
+Checksum package for AWS SDK for C. Contains
+Cross-Platform HW accelerated CRC32c and CRC32 with
+fallback to efficient SW implementations.
+
+
+%prep
+%autosetup
+
+
+%build
+%cmake -DBUILD_SHARED_LIBS=ON
+%cmake_build
+
+%install
+%cmake_install
+
+
+%files
+%license LICENSE
+%doc README.md
+
+%files libs
+%{_libdir}/libaws-checksums.so
+%{_libdir}/libaws-checksums.so.1.0.0
+
+%files devel
+%{_includedir}/aws/checksums/*.h
+
+%{_libdir}/aws-checksums/cmake/aws-checksums-config.cmake
+%{_libdir}/aws-checksums/cmake/shared/aws-checksums-targets-noconfig.cmake
+%{_libdir}/aws-checksums/cmake/shared/aws-checksums-targets.cmake
+
+
+%changelog
+* Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>
+- 

--- a/specs/s2n-tls.spec
+++ b/specs/s2n-tls.spec
@@ -13,7 +13,6 @@ BuildRequires: cmake
 BuildRequires: openssl-devel
 BuildRequires: ninja-build
 Requires:      openssl
-Requires:      %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
 
 %description
 s2n-tls is a C99 implementation of the TLS/SSL protocols that is
@@ -21,7 +20,7 @@ designed to be simple, small, fast, and with security as a priority.
 
 %package libs
 Summary: s2n: an implementation of the TLS/SSL protocols libraries
-
+Requires:      %{name}%{?_isa} = %{epoch}:%{version}-%{release}
 
 %description libs 
 s2n-tls is a C99 implementation of the TLS/SSL protocols that is
@@ -29,7 +28,8 @@ designed to be simple, small, fast, and with security as a priority.
 
 %package devel
 Summary: s2n: an implementation of the TLS/SSL protocols headers and source files.
-
+Requires:      %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:      openssl-devel
 
 %description devel
 Headers and Source files for s2n-tls is a C99 implementation of the
@@ -46,15 +46,19 @@ security as a priority.
 
 %install
 %cmake_install
-## rm -rf %{buildroot}%{_libdir}/s2n
 
 
 %files devel
 %{_includedir}/s2n.h
-%{_libdir}/libs2n.so
+%{_libdir}/s2n/cmake/modules/FindLibCrypto.cmake
+%{_libdir}/s2n/cmake/s2n-config.cmake
+%{_libdir}/s2n/cmake/shared/s2n-targets-noconfig.cmake
+%{_libdir}/s2n/cmake/shared/s2n-targets.cmake
+
 
 %files libs
 %license LICENSE
+%{_libdir}/libs2n.so
 
 %files
 %license LICENSE


### PR DESCRIPTION
This builds on this PR: https://github.com/davdunc/awscli-2-rpm/pull/11. So feel free to review that first and merge it or just review it all as part of this PR. I'm able to build all of the submodules using `mock` now.