### PR TITLE
Flesh out AWS CLI specfile

### DIFF
--- a/sources/awscli-2.patch
+++ b/sources/awscli-2.patch
@@ -1,0 +1,48 @@
+diff -urN aws-cli-2.4.12-orig/awscli/customizations/wizard/app.py aws-cli-2.4.12/awscli/customizations/wizard/app.py
+--- aws-cli-2.4.12-orig/awscli/customizations/wizard/app.py	2022-01-18 22:00:18.000000000 +0000
++++ aws-cli-2.4.12/awscli/customizations/wizard/app.py	2022-01-20 22:02:20.045784837 +0000
+@@ -12,10 +12,10 @@
+ # language governing permissions and limitations under the License.
+ import json
+ import os
++from asyncio import get_event_loop
+ from collections.abc import MutableMapping
+ 
+ from prompt_toolkit.application import Application
+-from prompt_toolkit.eventloop import get_event_loop, run_until_complete
+ 
+ from awscli.customizations.wizard import core
+ from awscli.customizations.wizard.ui.style import get_default_style
+@@ -68,7 +68,7 @@
+         loop.set_exception_handler(self._handle_exception)
+         try:
+             f = self.run_async(pre_run=pre_run)
+-            run_until_complete(f)
++            loop.run_until_complete(f)
+             return f.result()
+         finally:
+             loop.set_exception_handler(previous_exc_handler)
+diff -urN aws-cli-2.4.12-orig/setup.cfg aws-cli-2.4.12/setup.cfg
+--- aws-cli-2.4.12-orig/setup.cfg	2022-01-18 22:00:18.000000000 +0000
++++ aws-cli-2.4.12/setup.cfg	2022-01-20 21:49:45.335819606 +0000
+@@ -28,14 +28,13 @@
+ python_requires = >=3.7
+ include_package_data = True
+ install_requires =
+-    colorama>=0.2.5,<0.4.4
+-    docutils>=0.10,<0.16
+-    cryptography>=3.3.2,<3.4.0
+-    ruamel.yaml>=0.15.0,<0.16.0
+-    wcwidth<0.2.0
+-    prompt-toolkit>=2.0.0,<3.0.0
++    colorama>=0.2.5,<=0.4.4
++    docutils>=0.10,<=0.16
++    cryptography>=3.3.2,<36.0.0
++    ruamel.yaml>=0.15.0,<0.17.0
++    prompt-toolkit>=2.0.0,<3.1.0
+     distro>=1.5.0,<1.6.0
+-    awscrt==0.12.4
++    awscrt==0.12.6
+     python-dateutil>=2.1,<3.0.0
+     jmespath>=0.7.1,<1.0.0
+     urllib3>=1.25.4,<1.27

--- a/specs/awscli-2.spec
+++ b/specs/awscli-2.spec
@@ -1,23 +1,23 @@
 %global srcname aws-cli
 %global appname awscli
+
 %bcond_with examples
 
 Name:           %{appname}-2
-Version:        2.3.0
-Release:        2%{?dist}
+Version:        2.4.12
+Release:        1%{?dist}
 Summary:        Universal Command Line Environment for AWS, Version 2
 
 License:        ASL 2.0 and MIT
 URL:            https://github.com/aws/aws-cli
-Source0:        %{url}/archive/v2/%{version}/%{appname}-%{version}.tar.gz
+Source0:        %{url}/archive/%{version}/%{appname}-%{version}.tar.gz
+Patch0:         awscli-2.patch
 
 BuildArch:      noarch
-# The botocore library is no longer separate from the awscli
-# Requires:       python3-botocore-2
-Requires:       python3-cryptography
-Requires:       python3-s3transfer
 BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
+BuildRequires:  python3-toml
+BuildRequires:  python3-wheel
+
 Recommends:     groff
 Obsoletes:      awscli <= 1
 Obsoletes:      python3-botocore <= 1
@@ -29,42 +29,37 @@ Obsoletes:      python3-botocore <= 1
 This package provides version 2 of the unified command line
 interface to Amazon Web Services.
 
+
 %prep
-%autosetup -n %{srcname}-%{version}
+%autosetup -p1 -n %{srcname}-%{version}
 
 %if %{with examples}
 find awscli/examples/ -type f -name '*.rst' -executable -exec chmod -x '{}' +
 %else
-rm -vr awscli/examples
+rm -r awscli/examples
 %endif
 
+%generate_buildrequires
+%pyproject_buildrequires -r
+
 %build
-# cd %{srcname}-%{version}
-%py3_build
+%pyproject_wheel
+
 
 %install
-%py3_install
-rm -vf %{buildroot}%{_bindir}/{aws_bash_completer,aws_zsh_completer.sh,aws.cmd}
-install -Dpm0644 bin/aws_bash_completer \
-  %{buildroot}%{_datadir}/bash-completion/completions/aws
-install -Dpm0644 bin/aws_zsh_completer.sh \
-  %{buildroot}%{_datadir}/zsh/site-functions/_awscli
-install -Dpm0644 doc/* %{buildroot}%{_datadir}/
+%pyproject_install
 
-%files
-%doc %{name}/doc/README.rst
-%license %{name}/LICENSE.txt
+%pyproject_save_files awscli
+
+%files -f %{pyproject_files}
+%doc README.rst
+
 %{_bindir}/aws
+%{_bindir}/aws.cmd
+%{_bindir}/aws_bash_completer
 %{_bindir}/aws_completer
-%{_bindir}/aws_legacy_completer
-%{python3_sitelib}/awscli/
-%{python3_sitelib}/awscli-%{version}-*.egg-info/
-%dir %{_datadir}/bash-completion
-%dir %{_datadir}/bash-completion/completions
-%{_datadir}/bash-completion/completions/aws
-%dir %{_datadir}/zsh
-%dir %{_datadir}/zsh/site-functions
-%{_datadir}/zsh/site-functions/_awscli
+%{_bindir}/aws_zsh_completer.sh
+
 
 %changelog
 * Fri Mar 13 2020 David Duncan <davdunc@amazon.com> - 2.0.3-2


### PR DESCRIPTION
It now uses the pyproject macros which is the new standard and is needed to build the CLI.

It also required a patch to work with the dependencies currently in Fedora:

* Update the setup.cfg to loosen the version range of the packages required by the CLI
* Update usage of promptoolkit usage since its pin required bumping up to a new major version

We should be able to get rid of this patch once the version ranges are updated upstream. Most of these should be able to be updated.