### PR TITLE
Add patch to the aws-c-mqtt library

### DIFF
--- a/sources/aws-c-mqtt-reconnect-api.patch
+++ b/sources/aws-c-mqtt-reconnect-api.patch
@@ -1,0 +1,11 @@
+diff -urN aws-c-mqtt-0.7.8-orig/include/aws/mqtt/client.h aws-c-mqtt-0.7.8/include/aws/mqtt/client.h
+--- aws-c-mqtt-0.7.8-orig/include/aws/mqtt/client.h	2021-09-21 23:27:06.000000000 +0000
++++ aws-c-mqtt-0.7.8/include/aws/mqtt/client.h	2022-01-20 20:40:54.188622651 +0000
+@@ -418,6 +418,7 @@
+  * \returns AWS_OP_SUCCESS if the connection has been successfully initiated,
+  *              otherwise AWS_OP_ERR and aws_last_error() will be set.
+  */
++AWS_MQTT_API
+ int aws_mqtt_client_connection_reconnect(
+     struct aws_mqtt_client_connection *connection,
+     aws_mqtt_client_on_connection_complete_fn *on_connection_complete,

--- a/specs/aws-c-mqtt.spec
+++ b/specs/aws-c-mqtt.spec
@@ -1,12 +1,13 @@
 Name:           aws-c-mqtt
 Version:        0.7.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        C99 implementation of the MQTT 3.1.1 specification
 Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         aws-c-mqtt-reconnect-api.patch
 
 BuildRequires:  gcc
 BuildRequires:  cmake
@@ -45,7 +46,7 @@ C99 implementation of the MQTT 3.1.1 specification
 
 
 %prep
-%autosetup
+%autosetup -p1
 
 
 %build
@@ -77,5 +78,8 @@ C99 implementation of the MQTT 3.1.1 specification
 
 
 %changelog
+* Tue Jan 25 2022 Kyle Knapp <kyleknap@amazon.com> - 1:0.7.8-2
+- Add patch to make missing API accessible when a shared library
+
 * Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>
 - 


### PR DESCRIPTION
Downstream consumers (e.g. python-awscrt) rely on the deprecated API. By not marking it as part of the public API,
it causes runtime failures when importing python-awscrt because it uses the API and it fails to find the API's
definition as part of the shared library 