### PR TITLE
Epoch fix

### DIFF
--- a/specs/aws-c-auth.spec
+++ b/specs/aws-c-auth.spec
@@ -2,7 +2,6 @@ Name:           aws-c-auth
 Version:        0.6.5 
 Release:        1%{?dist}
 Summary:        C99 library implementation of AWS client-side authentication
-Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
@@ -33,7 +32,7 @@ standard credentials providers and signing
 
 %package libs
 Summary:        C99 library implementation of AWS client-side authentication
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description libs
 C99 library implementation of AWS client-side authentication:
@@ -42,7 +41,7 @@ standard credentials providers and signing
 
 %package devel
 Summary:        C99 library implementation of AWS client-side authentication
-Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description devel
 C99 library implementation of AWS client-side authentication:

--- a/specs/aws-c-auth.spec
+++ b/specs/aws-c-auth.spec
@@ -10,20 +10,20 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  gcc
 BuildRequires:  cmake
 BuildRequires:  openssl-devel
-BuildRequires:  aws-c-common-devel = 1:0.6.14
-BuildRequires:  aws-c-sdkutils-devel = 1:0.1.1
-BuildRequires:  aws-c-cal-devel = 1:0.5.12
-BuildRequires:  aws-c-io-devel = 1:0.10.12
-BuildRequires:  aws-c-compression-devel = 1:0.2.14
-BuildRequires:  aws-c-http-devel = 1:0.6.8
+BuildRequires:  aws-c-common-devel = 0.6.14
+BuildRequires:  aws-c-sdkutils-devel = 0.1.1
+BuildRequires:  aws-c-cal-devel = 0.5.12
+BuildRequires:  aws-c-io-devel = 0.10.12
+BuildRequires:  aws-c-compression-devel = 0.2.14
+BuildRequires:  aws-c-http-devel = 0.6.8
 
 Requires:       openssl
-Requires:       aws-c-common-libs = 1:0.6.14
-Requires:       aws-c-sdkutils-libs = 1:0.1.1
-Requires:       aws-c-cal-libs = 1:0.5.12
-Requires:       aws-c-io-libs = 1:0.10.12
-Requires:       aws-c-compression-libs = 1:0.2.14
-Requires:       aws-c-http-libs = 1:0.6.8
+Requires:       aws-c-common-libs = 0.6.14
+Requires:       aws-c-sdkutils-libs = 0.1.1
+Requires:       aws-c-cal-libs = 0.5.12
+Requires:       aws-c-io-libs = 0.10.12
+Requires:       aws-c-compression-libs = 0.2.14
+Requires:       aws-c-http-libs = 0.6.8
 
 %description
 C99 library implementation of AWS client-side authentication:

--- a/specs/aws-c-cal.spec
+++ b/specs/aws-c-cal.spec
@@ -9,10 +9,10 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc
 BuildRequires:  cmake
-BuildRequires:  aws-c-common-devel = 1:0.6.14
+BuildRequires:  aws-c-common-devel = 0.6.14
 BuildRequires:  openssl-devel
 
-Requires:       aws-c-common-libs = 1:0.6.14
+Requires:       aws-c-common-libs = 0.6.14
 Requires:       openssl
 
 %description

--- a/specs/aws-c-cal.spec
+++ b/specs/aws-c-cal.spec
@@ -2,7 +2,6 @@ Name:           aws-c-cal
 Version:        0.5.12 
 Release:        1%{?dist}
 Summary:        AWS Crypto Abstraction Layer
-Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
@@ -23,7 +22,7 @@ cryptography primitives
 
 %package libs
 Summary:        AWS Crypto Abstraction Layer
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 	
 %description libs
 AWS Crypto Abstraction Layer: Cross-Platform, C99 wrapper for
@@ -32,7 +31,7 @@ cryptography primitives
 
 %package devel
 Summary:        AWS Crypto Abstraction Layer
-Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description devel
 AWS Crypto Abstraction Layer: Cross-Platform, C99 wrapper for

--- a/specs/aws-c-common.spec
+++ b/specs/aws-c-common.spec
@@ -2,7 +2,6 @@ Name:           aws-c-common
 Version:        0.6.14 
 Release:        1%{?dist}
 Summary:        Core c99 package for AWS SDK for C
-Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
@@ -18,7 +17,7 @@ configuration, data structures, and error handling.
 
 %package libs
 Summary:        Core c99 package for AWS SDK for C
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description libs
 Core c99 package for AWS SDK for C. Includes cross-platform primitives,
@@ -27,7 +26,7 @@ configuration, data structures, and error handling.
 
 %package devel
 Summary:        Core c99 package for AWS SDK for C
-Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description devel
 Core c99 package for AWS SDK for C. Includes cross-platform primitives,

--- a/specs/aws-c-compression.spec
+++ b/specs/aws-c-compression.spec
@@ -2,7 +2,6 @@ Name:           aws-c-compression
 Version:        0.2.14
 Release:        1%{?dist}
 Summary:        Compression package for AWS SDK for C
-Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
@@ -21,7 +20,7 @@ compression algorithms such as gzip, and huffman encoding/decoding.
 
 %package libs
 Summary:        Compression package for AWS SDK for C
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 	
 %description libs
 This is a cross-platform C99 implementation of
@@ -30,7 +29,7 @@ compression algorithms such as gzip, and huffman encoding/decoding.
 
 %package devel
 Summary:        Compression package for AWS SDK for C
-Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description devel
 This is a cross-platform C99 implementation of

--- a/specs/aws-c-compression.spec
+++ b/specs/aws-c-compression.spec
@@ -9,9 +9,9 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc
 BuildRequires:  cmake
-BuildRequires:  aws-c-common-devel = 1:0.6.14
+BuildRequires:  aws-c-common-devel = 0.6.14
 
-Requires:       aws-c-common-libs = 1:0.6.14
+Requires:       aws-c-common-libs = 0.6.14
 
 %description
 This is a cross-platform C99 implementation of

--- a/specs/aws-c-event-stream.spec
+++ b/specs/aws-c-event-stream.spec
@@ -9,13 +9,13 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc
 BuildRequires:  cmake
-BuildRequires:  aws-c-common-devel = 1:0.6.14
-BuildRequires:  aws-checksums-devel = 1:0.1.12
-BuildRequires:  aws-c-io-devel = 1:0.10.12
+BuildRequires:  aws-c-common-devel = 0.6.14
+BuildRequires:  aws-checksums-devel = 0.1.12
+BuildRequires:  aws-c-io-devel = 0.10.12
 
-Requires:       aws-c-common-libs = 1:0.6.14
-Requires:       aws-checksums-libs = 1:0.1.12
-Requires:       aws-c-io-libs = 1:0.10.12
+Requires:       aws-c-common-libs = 0.6.14
+Requires:       aws-checksums-libs = 0.1.12
+Requires:       aws-c-io-libs = 0.10.12
 
 %description
 C99 implementation of the vnd.amazon.eventstream content-type

--- a/specs/aws-c-event-stream.spec
+++ b/specs/aws-c-event-stream.spec
@@ -2,7 +2,6 @@ Name:           aws-c-event-stream
 Version:        0.2.7 
 Release:        1%{?dist}
 Summary:        C99 implementation of the vnd.amazon.eventstream content-type
-Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
@@ -24,7 +23,7 @@ C99 implementation of the vnd.amazon.eventstream content-type
 
 %package libs
 Summary:        C99 implementation of the vnd.amazon.eventstream content-type
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description libs
 C99 implementation of the vnd.amazon.eventstream content-type
@@ -32,7 +31,7 @@ C99 implementation of the vnd.amazon.eventstream content-type
 
 %package devel
 Summary:        C99 implementation of the vnd.amazon.eventstream content-type
-Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description devel
 C99 implementation of the vnd.amazon.eventstream content-type

--- a/specs/aws-c-http.spec
+++ b/specs/aws-c-http.spec
@@ -9,13 +9,13 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc
 BuildRequires:  cmake
-BuildRequires:  aws-c-common-devel = 1:0.6.14
-BuildRequires:  aws-c-compression-devel = 1:0.2.14
-BuildRequires:  aws-c-io-devel = 1:0.10.12
+BuildRequires:  aws-c-common-devel = 0.6.14
+BuildRequires:  aws-c-compression-devel = 0.2.14
+BuildRequires:  aws-c-io-devel = 0.10.12
 
-Requires:       aws-c-common-libs = 1:0.6.14
-Requires:       aws-c-compression-libs = 1:0.2.14
-Requires:       aws-c-io-libs = 1:0.10.12
+Requires:       aws-c-common-libs = 0.6.14
+Requires:       aws-c-compression-libs = 0.2.14
+Requires:       aws-c-io-libs = 0.10.12
 
 %description
 C99 implementation of the HTTP/1.1 and HTTP/2 specifications

--- a/specs/aws-c-http.spec
+++ b/specs/aws-c-http.spec
@@ -2,7 +2,6 @@ Name:           aws-c-http
 Version:        0.6.8 
 Release:        1%{?dist}
 Summary:        C99 implementation of the HTTP/1.1 and HTTP/2 specifications
-Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
@@ -24,7 +23,7 @@ C99 implementation of the HTTP/1.1 and HTTP/2 specifications
 
 %package libs
 Summary:        C99 implementation of the HTTP/1.1 and HTTP/2 specifications
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description libs
 C99 implementation of the HTTP/1.1 and HTTP/2 specifications
@@ -32,7 +31,7 @@ C99 implementation of the HTTP/1.1 and HTTP/2 specifications
 
 %package devel
 Summary:        C99 implementation of the HTTP/1.1 and HTTP/2 specifications
-Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description devel
 C99 implementation of the HTTP/1.1 and HTTP/2 specifications

--- a/specs/aws-c-io.spec
+++ b/specs/aws-c-io.spec
@@ -10,12 +10,12 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  gcc
 BuildRequires:  cmake
 BuildRequires:  s2n-tls-devel
-BuildRequires:  aws-c-common-devel = 1:0.6.14
-BuildRequires:  aws-c-cal-devel = 1:0.5.12
+BuildRequires:  aws-c-common-devel = 0.6.14
+BuildRequires:  aws-c-cal-devel = 0.5.12
 
 Requires:       s2n-tls-libs
-Requires:       aws-c-common-libs = 1:0.6.14
-Requires:       aws-c-cal-libs = 1:0.5.12
+Requires:       aws-c-common-libs = 0.6.14
+Requires:       aws-c-cal-libs = 0.5.12
 
 %description
 IO package for AWS SDK for C. It handles all IO and TLS work
@@ -35,7 +35,7 @@ for application protocols.
 Summary:        IO package for AWS SDK for C
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 Requires:       s2n-tls-devel
-Requires:       aws-c-cal-devel = 1:0.5.12
+Requires:       aws-c-cal-devel = 0.5.12
 
 %description devel
 IO package for AWS SDK for C. It handles all IO and TLS work

--- a/specs/aws-c-io.spec
+++ b/specs/aws-c-io.spec
@@ -2,7 +2,6 @@ Name:           aws-c-io
 Version:        0.10.12 
 Release:        1%{?dist}
 Summary:        IO package for AWS SDK for C
-Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
@@ -25,7 +24,7 @@ for application protocols.
 
 %package libs
 Summary:        IO package for AWS SDK for C
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 	
 %description libs
 IO package for AWS SDK for C. It handles all IO and TLS work
@@ -34,7 +33,7 @@ for application protocols.
 
 %package devel
 Summary:        IO package for AWS SDK for C
-Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 Requires:       s2n-tls-devel
 Requires:       aws-c-cal-devel = 1:0.5.12
 

--- a/specs/aws-c-mqtt.spec
+++ b/specs/aws-c-mqtt.spec
@@ -11,18 +11,18 @@ Patch0:         aws-c-mqtt-reconnect-api.patch
 BuildRequires:  gcc
 BuildRequires:  cmake
 BuildRequires:  openssl-devel
-BuildRequires:  aws-c-common-devel = 1:0.6.14
-BuildRequires:  aws-c-cal-devel = 1:0.5.12
-BuildRequires:  aws-c-io-devel = 1:0.10.12
-BuildRequires:  aws-c-compression-devel = 1:0.2.14
-BuildRequires:  aws-c-http-devel = 1:0.6.8
+BuildRequires:  aws-c-common-devel = 0.6.14
+BuildRequires:  aws-c-cal-devel = 0.5.12
+BuildRequires:  aws-c-io-devel = 0.10.12
+BuildRequires:  aws-c-compression-devel = 0.2.14
+BuildRequires:  aws-c-http-devel = 0.6.8
 
 Requires:       openssl-devel
-Requires:       aws-c-common-libs = 1:0.6.14
-Requires:       aws-c-cal-libs = 1:0.5.12
-Requires:       aws-c-io-libs = 1:0.10.12
-Requires:       aws-c-compression-libs = 1:0.2.14
-Requires:       aws-c-http-libs = 1:0.6.8
+Requires:       aws-c-common-libs = 0.6.14
+Requires:       aws-c-cal-libs = 0.5.12
+Requires:       aws-c-io-libs = 0.10.12
+Requires:       aws-c-compression-libs = 0.2.14
+Requires:       aws-c-http-libs = 0.6.8
 
 %description
 C99 implementation of the MQTT 3.1.1 specification
@@ -77,7 +77,7 @@ C99 implementation of the MQTT 3.1.1 specification
 
 
 %changelog
-* Tue Jan 25 2022 Kyle Knapp <kyleknap@amazon.com> - 1:0.7.8-2
+* Tue Jan 25 2022 Kyle Knapp <kyleknap@amazon.com> - 0.7.8-2
 - Add patch to make missing API accessible when a shared library
 
 * Tue Jan 18 2022 Kyle Knapp <kyleknap@amazon.com>

--- a/specs/aws-c-mqtt.spec
+++ b/specs/aws-c-mqtt.spec
@@ -2,7 +2,6 @@ Name:           aws-c-mqtt
 Version:        0.7.8
 Release:        2%{?dist}
 Summary:        C99 implementation of the MQTT 3.1.1 specification
-Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
@@ -31,7 +30,7 @@ C99 implementation of the MQTT 3.1.1 specification
 
 %package libs
 Summary:        C99 implementation of the MQTT 3.1.1 specification
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description libs
 C99 implementation of the MQTT 3.1.1 specification
@@ -39,7 +38,7 @@ C99 implementation of the MQTT 3.1.1 specification
 
 %package devel
 Summary:        C99 implementation of the MQTT 3.1.1 specification
-Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description devel
 C99 implementation of the MQTT 3.1.1 specification

--- a/specs/aws-c-s3.spec
+++ b/specs/aws-c-s3.spec
@@ -9,21 +9,21 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc
 BuildRequires:  cmake
-BuildRequires:  aws-c-common-devel = 1:0.6.14
-BuildRequires:  aws-c-sdkutils-devel = 1:0.1.1
-BuildRequires:  aws-c-cal-devel = 1:0.5.12
-BuildRequires:  aws-c-compression-devel = 1:0.2.14
-BuildRequires:  aws-c-io-devel = 1:0.10.12
-BuildRequires:  aws-c-http-devel = 1:0.6.8
-BuildRequires:  aws-c-auth-devel = 1:0.6.5
+BuildRequires:  aws-c-common-devel = 0.6.14
+BuildRequires:  aws-c-sdkutils-devel = 0.1.1
+BuildRequires:  aws-c-cal-devel = 0.5.12
+BuildRequires:  aws-c-compression-devel = 0.2.14
+BuildRequires:  aws-c-io-devel = 0.10.12
+BuildRequires:  aws-c-http-devel = 0.6.8
+BuildRequires:  aws-c-auth-devel = 0.6.5
 
-Requires:       aws-c-common-libs = 1:0.6.14
-Requires:       aws-c-sdkutils-libs = 1:0.1.1
-Requires:       aws-c-cal-libs = 1:0.5.12
-Requires:       aws-c-compression-libs = 1:0.2.14
-Requires:       aws-c-io-libs = 1:0.10.12
-Requires:       aws-c-http-libs = 1:0.6.8
-Requires:       aws-c-auth-libs = 1:0.6.5
+Requires:       aws-c-common-libs = 0.6.14
+Requires:       aws-c-sdkutils-libs = 0.1.1
+Requires:       aws-c-cal-libs = 0.5.12
+Requires:       aws-c-compression-libs = 0.2.14
+Requires:       aws-c-io-libs = 0.10.12
+Requires:       aws-c-http-libs = 0.6.8
+Requires:       aws-c-auth-libs = 0.6.5
 
 %description
 C99 library implementation for communicating with the S3 service,

--- a/specs/aws-c-s3.spec
+++ b/specs/aws-c-s3.spec
@@ -2,7 +2,6 @@ Name:           aws-c-s3
 Version:        0.1.27
 Release:        1%{?dist}
 Summary:        C99 library implementation for communicating with the S3 service
-Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
@@ -32,7 +31,7 @@ designed for maximizing throughput on high bandwidth EC2 instances.
 
 %package libs
 Summary:        C99 library implementation for communicating with the S3 service
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description libs
 C99 library implementation for communicating with the S3 service,
@@ -41,7 +40,7 @@ designed for maximizing throughput on high bandwidth EC2 instances.
 
 %package devel
 Summary:        C99 library implementation for communicating with the S3 service
-Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description devel
 C99 library implementation for communicating with the S3 service,

--- a/specs/aws-c-sdkutils.spec
+++ b/specs/aws-c-sdkutils.spec
@@ -9,9 +9,9 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc
 BuildRequires:  cmake
-BuildRequires:  aws-c-common-devel = 1:0.6.14
+BuildRequires:  aws-c-common-devel = 0.6.14
 
-Requires:       aws-c-common-libs = 1:0.6.14
+Requires:       aws-c-common-libs = 0.6.14
 
 %description
 Utility package for AWS SDK for C

--- a/specs/aws-c-sdkutils.spec
+++ b/specs/aws-c-sdkutils.spec
@@ -2,7 +2,6 @@ Name:           aws-c-sdkutils
 Version:        0.1.1 
 Release:        1%{?dist}
 Summary:        Utility package for AWS SDK for C
-Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
@@ -20,7 +19,7 @@ Utility package for AWS SDK for C
 
 %package libs
 Summary:        Utility package for AWS SDK for C
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 	
 %description libs
 Utility package for AWS SDK for C
@@ -28,7 +27,7 @@ Utility package for AWS SDK for C
 
 %package devel
 Summary:        Utility package for AWS SDK for C
-Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description devel
 Utility package for AWS SDK for C

--- a/specs/aws-checksums.spec
+++ b/specs/aws-checksums.spec
@@ -2,7 +2,6 @@ Name:           aws-checksums
 Version:        0.1.12 
 Release:        1%{?dist}
 Summary:        Checksum package for AWS SDK for C
-Epoch:          1
 
 License:        ASL-2.0
 URL:            https://github.com/awslabs/%{name}
@@ -22,7 +21,7 @@ fallback to efficient SW implementations.
 
 %package libs
 Summary:        Checksum package for AWS SDK for C
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 	
 %description libs
 Checksum package for AWS SDK for C. Contains
@@ -32,7 +31,7 @@ fallback to efficient SW implementations.
 
 %package devel
 Summary:        Checksum package for AWS SDK for C
-Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description devel
 Checksum package for AWS SDK for C. Contains

--- a/specs/aws-checksums.spec
+++ b/specs/aws-checksums.spec
@@ -9,9 +9,9 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc
 BuildRequires:  cmake
-BuildRequires:  aws-c-common-devel = 1:0.6.14
+BuildRequires:  aws-c-common-devel = 0.6.14
 
-Requires:       aws-c-common-libs = 1:0.6.14
+Requires:       aws-c-common-libs = 0.6.14
 
 %description
 Checksum package for AWS SDK for C. Contains

--- a/specs/python-awscrt.spec
+++ b/specs/python-awscrt.spec
@@ -14,31 +14,31 @@ BuildRequires:  gcc
 BuildRequires:  cmake
 BuildRequires:  openssl-devel
 BuildRequires:  s2n-tls-devel
-BuildRequires:  aws-c-common-devel = 1:0.6.14
-BuildRequires:  aws-c-sdkutils-devel = 1:0.1.1
-BuildRequires:  aws-c-cal-devel = 1:0.5.12
-BuildRequires:  aws-c-io-devel = 1:0.10.12
-BuildRequires:  aws-checksums-devel = 1:0.1.12
-BuildRequires:  aws-c-compression-devel = 1:0.2.14
-BuildRequires:  aws-c-event-stream-devel = 1:0.2.7
-BuildRequires:  aws-c-http-devel = 1:0.6.8
-BuildRequires:  aws-c-auth-devel = 1:0.6.5
-BuildRequires:  aws-c-mqtt-devel = 1:0.7.8
-BuildRequires:  aws-c-s3-devel = 1:0.1.27
+BuildRequires:  aws-c-common-devel = 0.6.14
+BuildRequires:  aws-c-sdkutils-devel = 0.1.1
+BuildRequires:  aws-c-cal-devel = 0.5.12
+BuildRequires:  aws-c-io-devel = 0.10.12
+BuildRequires:  aws-checksums-devel = 0.1.12
+BuildRequires:  aws-c-compression-devel = 0.2.14
+BuildRequires:  aws-c-event-stream-devel = 0.2.7
+BuildRequires:  aws-c-http-devel = 0.6.8
+BuildRequires:  aws-c-auth-devel = 0.6.5
+BuildRequires:  aws-c-mqtt-devel = 0.7.8
+BuildRequires:  aws-c-s3-devel = 0.1.27
 
 Requires:  openssl
 Requires:  s2n-tls-libs
-Requires:  aws-c-common-libs = 1:0.6.14
-Requires:  aws-c-sdkutils-libs = 1:0.1.1
-Requires:  aws-c-cal-libs = 1:0.5.12
-Requires:  aws-c-io-libs = 1:0.10.12
-Requires:  aws-checksums-libs = 1:0.1.12
-Requires:  aws-c-compression-libs = 1:0.2.14
-Requires:  aws-c-event-stream-libs = 1:0.2.7
-Requires:  aws-c-http-libs = 1:0.6.8
-Requires:  aws-c-auth-libs = 1:0.6.5
-Requires:  aws-c-mqtt-libs = 1:0.7.8
-Requires:  aws-c-s3-libs = 1:0.1.27
+Requires:  aws-c-common-libs = 0.6.14
+Requires:  aws-c-sdkutils-libs = 0.1.1
+Requires:  aws-c-cal-libs = 0.5.12
+Requires:  aws-c-io-libs = 0.10.12
+Requires:  aws-checksums-libs = 0.1.12
+Requires:  aws-c-compression-libs = 0.2.14
+Requires:  aws-c-event-stream-libs = 0.2.7
+Requires:  aws-c-http-libs = 0.6.8
+Requires:  aws-c-auth-libs = 0.6.5
+Requires:  aws-c-mqtt-libs = 0.7.8
+Requires:  aws-c-s3-libs = 0.1.27
 
 
 %global _description %{expand:

--- a/specs/s2n-tls.spec
+++ b/specs/s2n-tls.spec
@@ -1,7 +1,6 @@
 Name:           s2n-tls
 Version:        1.3.2
 Release:        1%{?dist}
-Epoch:          1
 Summary:        s2n: an implementation of the TLS/SSL protocols utilities
 
 License:        ASL-2.0
@@ -20,7 +19,7 @@ designed to be simple, small, fast, and with security as a priority.
 
 %package libs
 Summary: s2n: an implementation of the TLS/SSL protocols libraries
-Requires:      %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:      %{name}%{?_isa} = %{version}-%{release}
 
 %description libs 
 s2n-tls is a C99 implementation of the TLS/SSL protocols that is
@@ -28,7 +27,7 @@ designed to be simple, small, fast, and with security as a priority.
 
 %package devel
 Summary: s2n: an implementation of the TLS/SSL protocols headers and source files.
-Requires:      %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:      %{name}-libs%{?_isa} = %{version}-%{release}
 Requires:      openssl-devel
 
 %description devel


### PR DESCRIPTION
The Epoch is not needed in this original submission. Remove the Epoch definition from the package and, if necessary later, we will reintroduce it when required. Remove the epoch designation. @ngompa pointed out that the definition could look like this: sed  s#%{epoch}:#%{?epoch:%{epoch}:}# *.spec , but that since we don't have it, we don't need to overcomplicate the spec file with unnecessary definitions. 