### PR TITLE
Update CRT modules based on package review

### DIFF
--- a/sources/aws-c-auth-cmake.patch
+++ b/sources/aws-c-auth-cmake.patch
@@ -1,0 +1,21 @@
+diff -urN aws-c-auth-0.6.5-orig/CMakeLists.txt aws-c-auth-0.6.5/CMakeLists.txt
+--- aws-c-auth-0.6.5-orig/CMakeLists.txt	2021-10-11 21:34:37.000000000 +0000
++++ aws-c-auth-0.6.5/CMakeLists.txt	2022-02-03 21:01:27.251192120 +0000
+@@ -119,7 +119,7 @@
+ endif()
+ 
+ install(EXPORT "${PROJECT_NAME}-targets"
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/${TARGET_DIR}/"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/${TARGET_DIR}/"
+         NAMESPACE AWS::
+         COMPONENT Development)
+ 
+@@ -128,7 +128,7 @@
+         @ONLY)
+ 
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/"
+         COMPONENT Development)
+ 
+ include(CTest)

--- a/sources/aws-c-cal-cmake.patch
+++ b/sources/aws-c-cal-cmake.patch
@@ -1,0 +1,27 @@
+diff -urN aws-c-cal-0.5.12-orig/CMakeLists.txt aws-c-cal-0.5.12/CMakeLists.txt
+--- aws-c-cal-0.5.12-orig/CMakeLists.txt	2021-09-07 17:35:32.000000000 +0000
++++ aws-c-cal-0.5.12/CMakeLists.txt	2022-02-03 18:42:49.460699118 +0000
+@@ -158,12 +158,12 @@
+ endif()
+ 
+ install(EXPORT "${PROJECT_NAME}-targets"
+-    DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/${TARGET_DIR}/"
++    DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/${TARGET_DIR}/"
+     NAMESPACE AWS::
+     COMPONENT Development)
+ 
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+-    DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake"
++    DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}"
+     COMPONENT Development)
+ 
+ list(APPEND EXPORT_MODULES
+@@ -171,7 +171,7 @@
+     )
+ 
+ install(FILES ${EXPORT_MODULES}
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/modules"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/modules"
+         COMPONENT Development)
+ 
+ if (NOT CMAKE_CROSSCOMPILING AND NOT BYO_CRYPTO)

--- a/sources/aws-c-compression-cmake.patch
+++ b/sources/aws-c-compression-cmake.patch
@@ -1,0 +1,21 @@
+diff -urN aws-c-compression-0.2.14-orig/CMakeLists.txt aws-c-compression-0.2.14/CMakeLists.txt
+--- aws-c-compression-0.2.14-orig/CMakeLists.txt	2021-07-19 16:32:41.000000000 +0000
++++ aws-c-compression-0.2.14/CMakeLists.txt	2022-02-03 20:46:34.497766827 +0000
+@@ -88,7 +88,7 @@
+ endif()
+ 
+ install(EXPORT "${PROJECT_NAME}-targets"
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/${TARGET_DIR}"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/${TARGET_DIR}"
+         NAMESPACE AWS::
+         COMPONENT Development)
+ 
+@@ -97,7 +97,7 @@
+         @ONLY)
+ 
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/"
+         COMPONENT Development)
+ 
+ option(BUILD_HUFFMAN_GENERATOR "Whether or not to build the aws-c-common-huffman-generator tool" OFF)

--- a/sources/aws-c-event-stream-cmake.patch
+++ b/sources/aws-c-event-stream-cmake.patch
@@ -1,0 +1,21 @@
+diff -urN aws-c-event-stream-0.2.7-orig/CMakeLists.txt aws-c-event-stream-0.2.7/CMakeLists.txt
+--- aws-c-event-stream-0.2.7-orig/CMakeLists.txt	2021-02-25 23:34:13.000000000 +0000
++++ aws-c-event-stream-0.2.7/CMakeLists.txt	2022-02-03 21:09:37.153327440 +0000
+@@ -91,7 +91,7 @@
+ endif()
+ 
+ install(EXPORT "${PROJECT_NAME}-targets"
+-    DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/${TARGET_DIR}/"
++    DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/${TARGET_DIR}/"
+     NAMESPACE AWS::
+     COMPONENT Development)
+ 
+@@ -100,7 +100,7 @@
+     @ONLY)
+ 
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+-    DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/"
++    DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/"
+     COMPONENT Development)
+ 
+ 

--- a/sources/aws-c-http-cmake.patch
+++ b/sources/aws-c-http-cmake.patch
@@ -1,0 +1,21 @@
+diff -urN aws-c-http-0.6.8-orig/CMakeLists.txt aws-c-http-0.6.8/CMakeLists.txt
+--- aws-c-http-0.6.8-orig/CMakeLists.txt	2021-10-15 20:44:19.000000000 +0000
++++ aws-c-http-0.6.8/CMakeLists.txt	2022-02-03 20:54:23.824939167 +0000
+@@ -83,7 +83,7 @@
+ endif()
+ 
+ install(EXPORT "${PROJECT_NAME}-targets"
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/${TARGET_DIR}/"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/${TARGET_DIR}/"
+         NAMESPACE AWS::
+         COMPONENT Development)
+ 
+@@ -92,7 +92,7 @@
+         @ONLY)
+ 
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/"
+         COMPONENT Development)
+ 
+ include(CTest)

--- a/sources/aws-c-io-cmake.patch
+++ b/sources/aws-c-io-cmake.patch
@@ -1,0 +1,21 @@
+diff -urN aws-c-io-0.10.12-orig/CMakeLists.txt aws-c-io-0.10.12/CMakeLists.txt
+--- aws-c-io-0.10.12-orig/CMakeLists.txt	2021-10-15 20:38:27.000000000 +0000
++++ aws-c-io-0.10.12/CMakeLists.txt	2022-02-03 20:32:20.985273443 +0000
+@@ -215,7 +215,7 @@
+ endif()
+ 
+ install(EXPORT "${PROJECT_NAME}-targets"
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/${TARGET_DIR}"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/${TARGET_DIR}"
+         NAMESPACE AWS::
+         COMPONENT Development)
+ 
+@@ -224,7 +224,7 @@
+         @ONLY)
+ 
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}"
+         COMPONENT Development)
+ 
+ if (NOT CMAKE_CROSSCOMPILING)

--- a/sources/aws-c-mqtt-cmake.patch
+++ b/sources/aws-c-mqtt-cmake.patch
@@ -1,0 +1,21 @@
+diff -urN aws-c-mqtt-0.7.8-orig/CMakeLists.txt aws-c-mqtt-0.7.8/CMakeLists.txt
+--- aws-c-mqtt-0.7.8-orig/CMakeLists.txt	2021-09-21 23:27:06.000000000 +0000
++++ aws-c-mqtt-0.7.8/CMakeLists.txt	2022-02-03 21:17:48.579461451 +0000
+@@ -94,7 +94,7 @@
+ endif()
+ 
+ install(EXPORT "${PROJECT_NAME}-targets"
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/${TARGET_DIR}"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/${TARGET_DIR}"
+         NAMESPACE AWS::
+         COMPONENT Development)
+ 
+@@ -103,7 +103,7 @@
+         @ONLY)
+ 
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/"
+         COMPONENT Development)
+ 
+ include(CTest)

--- a/sources/aws-c-sdkutils-cmake.patch
+++ b/sources/aws-c-sdkutils-cmake.patch
@@ -1,0 +1,23 @@
+diff -urN aws-c-sdkutils-0.1.1-orig/CMakeLists.txt aws-c-sdkutils-0.1.1/CMakeLists.txt
+--- aws-c-sdkutils-0.1.1-orig/CMakeLists.txt	2021-10-12 23:38:33.000000000 +0000
++++ aws-c-sdkutils-0.1.1/CMakeLists.txt	2022-02-03 17:58:49.294211483 +0000
+@@ -94,16 +94,16 @@
+ endif()
+ 
+ install(EXPORT "${PROJECT_NAME}-targets"
+-    DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/${TARGET_DIR}/"
++    DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/${TARGET_DIR}/"
+     NAMESPACE AWS::
+     COMPONENT Development)
+ 
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+-    DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake"
++    DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}"
+     COMPONENT Development)
+ 
+ install(FILES ${EXPORT_MODULES}
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/modules"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/modules"
+         COMPONENT Development)
+ 
+ if (NOT CMAKE_CROSSCOMPILING)

--- a/sources/aws-checksums-cmake.patch
+++ b/sources/aws-checksums-cmake.patch
@@ -1,0 +1,21 @@
+diff -urN aws-checksums-0.1.12-orig/CMakeLists.txt aws-checksums-0.1.12/CMakeLists.txt
+--- aws-checksums-0.1.12-orig/CMakeLists.txt	2021-09-30 21:08:32.000000000 +0000
++++ aws-checksums-0.1.12/CMakeLists.txt	2022-02-03 20:21:24.674432672 +0000
+@@ -141,7 +141,7 @@
+ endif()
+ 
+ install(EXPORT "${PROJECT_NAME}-targets"
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/${TARGET_DIR}"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/${TARGET_DIR}"
+         NAMESPACE AWS::
+         COMPONENT Development)
+ 
+@@ -150,7 +150,7 @@
+         @ONLY)
+ 
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/"
++        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${PROJECT_NAME}/"
+         COMPONENT Development)
+ 
+ include(CTest)

--- a/specs/aws-c-auth.spec
+++ b/specs/aws-c-auth.spec
@@ -1,11 +1,12 @@
 Name:           aws-c-auth
 Version:        0.6.5 
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        C99 library implementation of AWS client-side authentication
 
 License:        ASL 2.0
 URL:            https://github.com/awslabs/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         aws-c-auth-cmake.patch
 
 BuildRequires:  gcc
 BuildRequires:  cmake
@@ -32,7 +33,6 @@ standard credentials providers and signing
 
 %package libs
 Summary:        C99 library implementation of AWS client-side authentication
-Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description libs
 C99 library implementation of AWS client-side authentication:
@@ -49,7 +49,7 @@ standard credentials providers and signing
 
 
 %prep
-%autosetup
+%autosetup -p1
 
 
 %build
@@ -75,6 +75,9 @@ standard credentials providers and signing
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.6.5-4
+- Add patch to set CMake configs to correct path
+
 * Thu Feb 03 2022 David Duncan <davdunc@amazon.com> - 0.6.5-3
 - Fix CMake targets and move files to lib
 

--- a/specs/aws-c-cal.spec
+++ b/specs/aws-c-cal.spec
@@ -1,11 +1,12 @@
 Name:           aws-c-cal
 Version:        0.5.12 
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        AWS Crypto Abstraction Layer
 
 License:        ASL 2.0
 URL:            https://github.com/awslabs/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         aws-c-cal-cmake.patch
 
 BuildRequires:  gcc
 BuildRequires:  cmake
@@ -22,8 +23,7 @@ cryptography primitives
 
 %package libs
 Summary:        AWS Crypto Abstraction Layer
-Requires:       %{name}%{?_isa} = %{version}-%{release}
-	
+
 %description libs
 AWS Crypto Abstraction Layer: Cross-Platform, C99 wrapper for
 cryptography primitives
@@ -39,7 +39,7 @@ cryptography primitives
 
 
 %prep
-%autosetup
+%autosetup -p1
 
 
 %build
@@ -50,26 +50,26 @@ cryptography primitives
 %cmake_install
 
 
-%files
+%files libs
 %license LICENSE
 %doc README.md
-
 %{_bindir}/sha256_profile
-
-%files libs
-%{_libdir}/libaws-c-cal.so
 %{_libdir}/libaws-c-cal.so.1.0.0
 
 %files devel
 %{_includedir}/aws/cal/*.h
 
-%{_libdir}/aws-c-cal/cmake/aws-c-cal-config.cmake
-%{_libdir}/aws-c-cal/cmake/modules/FindLibCrypto.cmake
-%{_libdir}/aws-c-cal/cmake/shared/aws-c-cal-targets-noconfig.cmake
-%{_libdir}/aws-c-cal/cmake/shared/aws-c-cal-targets.cmake
+%{_libdir}/libaws-c-cal.so
+%{_libdir}/cmake/aws-c-cal/aws-c-cal-config.cmake
+%{_libdir}/cmake/aws-c-cal/modules/FindLibCrypto.cmake
+%{_libdir}/cmake/aws-c-cal/shared/aws-c-cal-targets-noconfig.cmake
+%{_libdir}/cmake/aws-c-cal/shared/aws-c-cal-targets.cmake
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.5.12-3
+- Update specfile based on review feedback
+
 * Wed Feb 02 2022 David Duncan <davdunc@amazon.com> - 0.5.12-2
 - Prepare for package review
 

--- a/specs/aws-c-compression.spec
+++ b/specs/aws-c-compression.spec
@@ -1,11 +1,12 @@
 Name:           aws-c-compression
 Version:        0.2.14
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Compression package for AWS SDK for C
 
 License:        ASL 2.0
 URL:            https://github.com/awslabs/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         aws-c-compression-cmake.patch
 
 BuildRequires:  gcc
 BuildRequires:  cmake
@@ -20,8 +21,7 @@ compression algorithms such as gzip, and huffman encoding/decoding.
 
 %package libs
 Summary:        Compression package for AWS SDK for C
-Requires:       %{name}%{?_isa} = %{version}-%{release}
-	
+
 %description libs
 This is a cross-platform C99 implementation of
 compression algorithms such as gzip, and huffman encoding/decoding.
@@ -37,7 +37,7 @@ compression algorithms such as gzip, and huffman encoding/decoding.
 
 
 %prep
-%autosetup
+%autosetup -p1
 
 
 %build
@@ -48,23 +48,24 @@ compression algorithms such as gzip, and huffman encoding/decoding.
 %cmake_install
 
 
-%files
+%files libs
 %license LICENSE
 %doc README.md
-
-%files libs
-%{_libdir}/libaws-c-compression.so
 %{_libdir}/libaws-c-compression.so.1.0.0
 
 %files devel
 %{_includedir}/aws/compression/*.h
 
-%{_libdir}/aws-c-compression/cmake/aws-c-compression-config.cmake
-%{_libdir}/aws-c-compression/cmake/shared/aws-c-compression-targets-noconfig.cmake
-%{_libdir}/aws-c-compression/cmake/shared/aws-c-compression-targets.cmake
+%{_libdir}/libaws-c-compression.so
+%{_libdir}/cmake/aws-c-compression/aws-c-compression-config.cmake
+%{_libdir}/cmake/aws-c-compression/shared/aws-c-compression-targets-noconfig.cmake
+%{_libdir}/cmake/aws-c-compression/shared/aws-c-compression-targets.cmake
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.2.14-3
+- Update specfile based on review feedback
+
 * Wed Feb 02 2022 David Duncan <davdunc@amazon.com> - 0.2.14-2
 - Prepare for package review
 

--- a/specs/aws-c-event-stream.spec
+++ b/specs/aws-c-event-stream.spec
@@ -1,11 +1,12 @@
 Name:           aws-c-event-stream
 Version:        0.2.7 
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        C99 implementation of the vnd.amazon.eventstream content-type
 
 License:        ASL 2.0
 URL:            https://github.com/awslabs/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         aws-c-event-stream-cmake.patch
 
 BuildRequires:  gcc
 BuildRequires:  cmake
@@ -23,7 +24,6 @@ C99 implementation of the vnd.amazon.eventstream content-type
 
 %package libs
 Summary:        C99 implementation of the vnd.amazon.eventstream content-type
-Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description libs
 C99 implementation of the vnd.amazon.eventstream content-type
@@ -38,7 +38,7 @@ C99 implementation of the vnd.amazon.eventstream content-type
 
 
 %prep
-%autosetup
+%autosetup -p1
 
 
 %build
@@ -49,23 +49,24 @@ C99 implementation of the vnd.amazon.eventstream content-type
 %cmake_install
 
 
-%files
+%files libs
 %license LICENSE
 %doc README.md
-
-%files libs
-%{_libdir}/libaws-c-event-stream.so
 %{_libdir}/libaws-c-event-stream.so.1.0.0
 
 %files devel
 %{_includedir}/aws/event-stream/*.h
 
-%{_libdir}/aws-c-event-stream/cmake/aws-c-event-stream-config.cmake
-%{_libdir}/aws-c-event-stream/cmake/shared/aws-c-event-stream-targets-noconfig.cmake
-%{_libdir}/aws-c-event-stream/cmake/shared/aws-c-event-stream-targets.cmake
+%{_libdir}/libaws-c-event-stream.so
+%{_libdir}/cmake/aws-c-event-stream/aws-c-event-stream-config.cmake
+%{_libdir}/cmake/aws-c-event-stream/shared/aws-c-event-stream-targets-noconfig.cmake
+%{_libdir}/cmake/aws-c-event-stream/shared/aws-c-event-stream-targets.cmake
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.2.7-3
+- Update specfile based on review feedback
+
 * Wed Feb 02 2022 David Duncan <davdunc@amazon.com> - 0.2.7-2
 - Prepare for package review
 

--- a/specs/aws-c-http.spec
+++ b/specs/aws-c-http.spec
@@ -1,11 +1,12 @@
 Name:           aws-c-http
 Version:        0.6.8 
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        C99 implementation of the HTTP/1.1 and HTTP/2 specifications
 
 License:        ASL 2.0
 URL:            https://github.com/awslabs/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         aws-c-http-cmake.patch
 
 BuildRequires:  gcc
 BuildRequires:  cmake
@@ -23,7 +24,6 @@ C99 implementation of the HTTP/1.1 and HTTP/2 specifications
 
 %package libs
 Summary:        C99 implementation of the HTTP/1.1 and HTTP/2 specifications
-Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description libs
 C99 implementation of the HTTP/1.1 and HTTP/2 specifications
@@ -38,7 +38,7 @@ C99 implementation of the HTTP/1.1 and HTTP/2 specifications
 
 
 %prep
-%autosetup
+%autosetup -p1
 
 
 %build
@@ -49,25 +49,25 @@ C99 implementation of the HTTP/1.1 and HTTP/2 specifications
 %cmake_install
 
 
-%files
+%files libs
 %license LICENSE
 %doc README.md
-
 %{_bindir}/elasticurl
-
-%files libs
-%{_libdir}/libaws-c-http.so
 %{_libdir}/libaws-c-http.so.1.0.0
 
 %files devel
 %{_includedir}/aws/http/*.h
 
-%{_libdir}/aws-c-http/cmake/aws-c-http-config.cmake
-%{_libdir}/aws-c-http/cmake/shared/aws-c-http-targets-noconfig.cmake
-%{_libdir}/aws-c-http/cmake/shared/aws-c-http-targets.cmake
+%{_libdir}/libaws-c-http.so
+%{_libdir}/cmake/aws-c-http/aws-c-http-config.cmake
+%{_libdir}/cmake/aws-c-http/shared/aws-c-http-targets-noconfig.cmake
+%{_libdir}/cmake/aws-c-http/shared/aws-c-http-targets.cmake
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.6.8-3
+- Update specfile based on review feedback
+
 * Wed Feb 02 2022 David Duncan <davdunc@amazon.com> - 0.6.8-2
 - Prepare for package review
 

--- a/specs/aws-c-io.spec
+++ b/specs/aws-c-io.spec
@@ -1,11 +1,12 @@
 Name:           aws-c-io
 Version:        0.10.12 
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        IO package for AWS SDK for C
 
 License:        ASL 2.0
 URL:            https://github.com/awslabs/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         aws-c-io-cmake.patch
 
 BuildRequires:  gcc
 BuildRequires:  cmake
@@ -24,8 +25,7 @@ for application protocols.
 
 %package libs
 Summary:        IO package for AWS SDK for C
-Requires:       %{name}%{?_isa} = %{version}-%{release}
-	
+
 %description libs
 IO package for AWS SDK for C. It handles all IO and TLS work
 for application protocols.
@@ -43,7 +43,7 @@ for application protocols.
 
 
 %prep
-%autosetup
+%autosetup -p1
 
 
 %build
@@ -54,24 +54,25 @@ for application protocols.
 %cmake_install
 
 
-%files
+%files libs
 %license LICENSE
 %doc README.md
-
-%files libs
-%{_libdir}/libaws-c-io.so
 %{_libdir}/libaws-c-io.so.1.0.0
 
 %files devel
 %{_includedir}/aws/io/*.h
 %{_includedir}/aws/testing/io_testing_channel.h
 
-%{_libdir}/aws-c-io/cmake/aws-c-io-config.cmake
-%{_libdir}/aws-c-io/cmake/shared/aws-c-io-targets-noconfig.cmake
-%{_libdir}/aws-c-io/cmake/shared/aws-c-io-targets.cmake
+%{_libdir}/libaws-c-io.so
+%{_libdir}/cmake/aws-c-io/aws-c-io-config.cmake
+%{_libdir}/cmake/aws-c-io/shared/aws-c-io-targets-noconfig.cmake
+%{_libdir}/cmake/aws-c-io/shared/aws-c-io-targets.cmake
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.10.12-3
+- Update specfile based on review feedback
+
 * Wed Feb 02 2022 David Duncan <davdunc@amazon.com> - 0.10.12-2
 - Prepare for package review
 

--- a/specs/aws-c-mqtt.spec
+++ b/specs/aws-c-mqtt.spec
@@ -1,12 +1,13 @@
 Name:           aws-c-mqtt
 Version:        0.7.8
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        C99 implementation of the MQTT 3.1.1 specification
 
 License:        ASL 2.0
 URL:            https://github.com/awslabs/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 Patch0:         aws-c-mqtt-reconnect-api.patch
+Patch1:         aws-c-mqtt-cmake.patch
 
 BuildRequires:  gcc
 BuildRequires:  cmake
@@ -30,7 +31,6 @@ C99 implementation of the MQTT 3.1.1 specification
 
 %package libs
 Summary:        C99 implementation of the MQTT 3.1.1 specification
-Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description libs
 C99 implementation of the MQTT 3.1.1 specification
@@ -56,27 +56,27 @@ C99 implementation of the MQTT 3.1.1 specification
 %cmake_install
 
 
-%files
+%files libs
 %license LICENSE
 %doc README.md
-
 %{_bindir}/elastipubsub
-
-%files libs
-%{_libdir}/libaws-c-mqtt.so
 %{_libdir}/libaws-c-mqtt.so.1.0.0
 
 %files devel
 %{_includedir}/aws/mqtt/*.h
 %{_includedir}/aws/mqtt/private/mqtt_client_test_helper.h
 
-%{_libdir}/aws-c-mqtt/cmake/aws-c-mqtt-config.cmake
-%{_libdir}/aws-c-mqtt/cmake/shared/aws-c-mqtt-targets-noconfig.cmake
-%{_libdir}/aws-c-mqtt/cmake/shared/aws-c-mqtt-targets.cmake
+%{_libdir}/libaws-c-mqtt.so
+%{_libdir}/cmake/aws-c-mqtt/aws-c-mqtt-config.cmake
+%{_libdir}/cmake/aws-c-mqtt/shared/aws-c-mqtt-targets-noconfig.cmake
+%{_libdir}/cmake/aws-c-mqtt/shared/aws-c-mqtt-targets.cmake
 
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.7.8-4
+- Update specfile based on review feedback
+
 * Wed Feb 02 2022 David Duncan <davdunc@amazon.com> - 0.7.8-3
 - Prepare for package review
 

--- a/specs/aws-c-s3.spec
+++ b/specs/aws-c-s3.spec
@@ -1,11 +1,12 @@
 Name:           aws-c-s3
 Version:        0.1.27
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        C99 library implementation for communicating with the S3 service
 
 License:        ASL 2.0
 URL:            https://github.com/awslabs/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         aws-c-s3-cmake.patch
 
 BuildRequires:  gcc
 BuildRequires:  cmake
@@ -31,7 +32,6 @@ designed for maximizing throughput on high bandwidth EC2 instances.
 
 %package libs
 Summary:        C99 library implementation for communicating with the S3 service
-Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description libs
 C99 library implementation for communicating with the S3 service,
@@ -48,7 +48,7 @@ designed for maximizing throughput on high bandwidth EC2 instances.
 
 
 %prep
-%autosetup
+%autosetup -p1
 
 
 %build
@@ -59,25 +59,26 @@ designed for maximizing throughput on high bandwidth EC2 instances.
 %cmake_install
 
 
-%files
+%files libs
 %license LICENSE
 %doc README.md
-
-%files libs
-%{_libdir}/libaws-c-s3.so
 %{_libdir}/libaws-c-s3.so.0unstable
 %{_libdir}/libaws-c-s3.so.1.0.0
 
 %files devel
 %{_includedir}/aws/s3/*.h
 
-%{_libdir}/aws-c-s3/cmake/aws-c-s3-config.cmake
-%{_libdir}/aws-c-s3/cmake/shared/aws-c-s3-targets-noconfig.cmake
-%{_libdir}/aws-c-s3/cmake/shared/aws-c-s3-targets.cmake
+%{_libdir}/libaws-c-s3.so
+%{_libdir}/cmake/aws-c-s3/aws-c-s3-config.cmake
+%{_libdir}/cmake/aws-c-s3/shared/aws-c-s3-targets-noconfig.cmake
+%{_libdir}/cmake/aws-c-s3/shared/aws-c-s3-targets.cmake
 
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.1.27-3
+- Update specfile based on review feedback
+
 * Wed Feb 02 2022 David Duncan <davdunc@amazon.com> - 0.1.27-2
 - Prepare for package review
 

--- a/specs/aws-c-sdkutils.spec
+++ b/specs/aws-c-sdkutils.spec
@@ -1,11 +1,12 @@
 Name:           aws-c-sdkutils
 Version:        0.1.1 
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Utility package for AWS SDK for C
 
 License:        ASL 2.0
 URL:            https://github.com/awslabs/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         aws-c-sdkutils-cmake.patch
 
 BuildRequires:  gcc
 BuildRequires:  cmake
@@ -19,8 +20,7 @@ Utility package for AWS SDK for C
 
 %package libs
 Summary:        Utility package for AWS SDK for C
-Requires:       %{name}%{?_isa} = %{version}-%{release}
-	
+
 %description libs
 Utility package for AWS SDK for C
 
@@ -34,7 +34,7 @@ Utility package for AWS SDK for C
 
 
 %prep
-%autosetup
+%autosetup -p1
 
 
 %build
@@ -45,23 +45,25 @@ Utility package for AWS SDK for C
 %cmake_install
 
 
-%files
-%license LICENSE
-%doc README.md
 
 %files libs
-%{_libdir}/libaws-c-sdkutils.so
+%license LICENSE
+%doc README.md
 %{_libdir}/libaws-c-sdkutils.so.1.0.0
 
 %files devel
 %{_includedir}/aws/sdkutils/*.h
 
-%{_libdir}/aws-c-sdkutils/cmake/aws-c-sdkutils-config.cmake
-%{_libdir}/aws-c-sdkutils/cmake/shared/aws-c-sdkutils-targets-noconfig.cmake
-%{_libdir}/aws-c-sdkutils/cmake/shared/aws-c-sdkutils-targets.cmake
+%{_libdir}/libaws-c-sdkutils.so
+%{_libdir}/cmake/aws-c-sdkutils/aws-c-sdkutils-config.cmake
+%{_libdir}/cmake/aws-c-sdkutils/shared/aws-c-sdkutils-targets-noconfig.cmake
+%{_libdir}/cmake/aws-c-sdkutils/shared/aws-c-sdkutils-targets.cmake
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.1.1-3
+- Update specfile based on review feedback
+
 * Wed Feb 02 2022 David Duncan <davdunc@amazon.com> - 0.1.1-2
 - Prepare for package review
 

--- a/specs/aws-checksums.spec
+++ b/specs/aws-checksums.spec
@@ -1,11 +1,12 @@
 Name:           aws-checksums
 Version:        0.1.12 
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Checksum package for AWS SDK for C
 
 License:        ASL 2.0
 URL:            https://github.com/awslabs/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         aws-checksums-cmake.patch
 
 BuildRequires:  gcc
 BuildRequires:  cmake
@@ -21,8 +22,7 @@ fallback to efficient SW implementations.
 
 %package libs
 Summary:        Checksum package for AWS SDK for C
-Requires:       %{name}%{?_isa} = %{version}-%{release}
-	
+
 %description libs
 Checksum package for AWS SDK for C. Contains
 Cross-Platform HW accelerated CRC32c and CRC32 with
@@ -40,7 +40,7 @@ fallback to efficient SW implementations.
 
 
 %prep
-%autosetup
+%autosetup -p1
 
 
 %build
@@ -51,23 +51,24 @@ fallback to efficient SW implementations.
 %cmake_install
 
 
-%files
+%files libs
 %license LICENSE
 %doc README.md
-
-%files libs
-%{_libdir}/libaws-checksums.so
 %{_libdir}/libaws-checksums.so.1.0.0
 
 %files devel
 %{_includedir}/aws/checksums/*.h
 
-%{_libdir}/aws-checksums/cmake/aws-checksums-config.cmake
-%{_libdir}/aws-checksums/cmake/shared/aws-checksums-targets-noconfig.cmake
-%{_libdir}/aws-checksums/cmake/shared/aws-checksums-targets.cmake
+%{_libdir}/libaws-checksums.so
+%{_libdir}/cmake/aws-checksums/aws-checksums-config.cmake
+%{_libdir}/cmake/aws-checksums/shared/aws-checksums-targets-noconfig.cmake
+%{_libdir}/cmake/aws-checksums/shared/aws-checksums-targets.cmake
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.1.12-3
+- Update specfile based on review feedback
+
 * Wed Feb 02 2022 David Duncan <davdunc@amazon.com> - 0.1.12-2
 - Prepare for package review
 


### PR DESCRIPTION
Closes #31 and #32. In general, it required collapsing the standard package into the `libs` package and updating the cmake paths to `<libdir>/cmake/<name>` instead of `<libdir>/<name>/cmake`