### PR TITLE
Move aws-c-* executables to standard package

### DIFF
--- a/specs/aws-c-cal.spec
+++ b/specs/aws-c-cal.spec
@@ -1,6 +1,6 @@
 Name:           aws-c-cal
 Version:        0.5.12 
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        AWS Crypto Abstraction Layer
 
 License:        ASL 2.0
@@ -15,6 +15,7 @@ BuildRequires:  openssl-devel
 
 Requires:       aws-c-common-libs = 0.6.14
 Requires:       openssl
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description
 AWS Crypto Abstraction Layer: Cross-Platform, C99 wrapper for
@@ -49,11 +50,12 @@ cryptography primitives
 %install
 %cmake_install
 
+%files
+%{_bindir}/sha256_profile
 
 %files libs
 %license LICENSE
 %doc README.md
-%{_bindir}/sha256_profile
 %{_libdir}/libaws-c-cal.so.1.0.0
 
 %files devel
@@ -67,6 +69,9 @@ cryptography primitives
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.5.12-4
+- Move sha256_profile executable to standard package
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.5.12-3
 - Update specfile based on review feedback
 

--- a/specs/aws-c-http.spec
+++ b/specs/aws-c-http.spec
@@ -1,6 +1,6 @@
 Name:           aws-c-http
 Version:        0.6.8 
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        C99 implementation of the HTTP/1.1 and HTTP/2 specifications
 
 License:        ASL 2.0
@@ -17,6 +17,7 @@ BuildRequires:  aws-c-io-devel = 0.10.12
 Requires:       aws-c-common-libs = 0.6.14
 Requires:       aws-c-compression-libs = 0.2.14
 Requires:       aws-c-io-libs = 0.10.12
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description
 C99 implementation of the HTTP/1.1 and HTTP/2 specifications
@@ -49,10 +50,12 @@ C99 implementation of the HTTP/1.1 and HTTP/2 specifications
 %cmake_install
 
 
+%files
+%{_bindir}/elasticurl
+
 %files libs
 %license LICENSE
 %doc README.md
-%{_bindir}/elasticurl
 %{_libdir}/libaws-c-http.so.1.0.0
 
 %files devel
@@ -65,6 +68,9 @@ C99 implementation of the HTTP/1.1 and HTTP/2 specifications
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.6.8-4
+- Move elasticurl executable to standard package
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.6.8-3
 - Update specfile based on review feedback
 

--- a/specs/aws-c-mqtt.spec
+++ b/specs/aws-c-mqtt.spec
@@ -1,6 +1,6 @@
 Name:           aws-c-mqtt
 Version:        0.7.8
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        C99 implementation of the MQTT 3.1.1 specification
 
 License:        ASL 2.0
@@ -24,6 +24,7 @@ Requires:       aws-c-cal-libs = 0.5.12
 Requires:       aws-c-io-libs = 0.10.12
 Requires:       aws-c-compression-libs = 0.2.14
 Requires:       aws-c-http-libs = 0.6.8
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description
 C99 implementation of the MQTT 3.1.1 specification
@@ -55,11 +56,12 @@ C99 implementation of the MQTT 3.1.1 specification
 %install
 %cmake_install
 
+%files
+%{_bindir}/elastipubsub
 
 %files libs
 %license LICENSE
 %doc README.md
-%{_bindir}/elastipubsub
 %{_libdir}/libaws-c-mqtt.so.1.0.0
 
 %files devel
@@ -74,6 +76,9 @@ C99 implementation of the MQTT 3.1.1 specification
 
 
 %changelog
+* Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.7.8-5
+- Move elastipubsub executable to standard package
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.7.8-4
 - Update specfile based on review feedback
 


### PR DESCRIPTION
Fixes #34. This was accomplished by making the standard package rely on the `libs` package and moving the executable to the standard package. This was chosen over just moving all of the files from the `libs` package to the standard package because it makes it more consistent naming when declaring cross-CRT dependencies. Furthermore none of the CRT modules need these executables to function properly.