### PR TITLE
Add missing devel directories for all aws-c-* libraries

### DIFF
--- a/specs/aws-c-auth.spec
+++ b/specs/aws-c-auth.spec
@@ -1,6 +1,6 @@
 Name:           aws-c-auth
 Version:        0.6.5 
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        C99 library implementation of AWS client-side authentication
 
 License:        ASL 2.0
@@ -66,8 +66,11 @@ standard credentials providers and signing
 %{_libdir}/libaws-c-auth.so.1.0.0
 
 %files devel
+%dir %{_includedir}/aws/auth
 %{_includedir}/aws/auth/*.h
 %{_libdir}/libaws-c-auth.so
+%dir %{_libdir}/cmake/aws-c-auth
+%dir %{_libdir}/cmake/aws-c-auth/shared
 %{_libdir}/cmake/aws-c-auth/aws-c-auth-config.cmake
 %{_libdir}/cmake/aws-c-auth/shared/aws-c-auth-targets-noconfig.cmake
 %{_libdir}/cmake/aws-c-auth/shared/aws-c-auth-targets.cmake
@@ -75,6 +78,9 @@ standard credentials providers and signing
 
 
 %changelog
+* Tue Feb 22 2022 Kyle Knapp <kyleknap@amazon.com> - 0.6.5-5
+- Include missing devel directories
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.6.5-4
 - Add patch to set CMake configs to correct path
 

--- a/specs/aws-c-cal.spec
+++ b/specs/aws-c-cal.spec
@@ -1,6 +1,6 @@
 Name:           aws-c-cal
 Version:        0.5.12 
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        AWS Crypto Abstraction Layer
 
 License:        ASL 2.0
@@ -59,8 +59,12 @@ cryptography primitives
 %{_libdir}/libaws-c-cal.so.1.0.0
 
 %files devel
+%dir %{_includedir}/aws/cal
 %{_includedir}/aws/cal/*.h
 
+%dir %{_libdir}/cmake/aws-c-cal
+%dir %{_libdir}/cmake/aws-c-cal/modules
+%dir %{_libdir}/cmake/aws-c-cal/shared
 %{_libdir}/libaws-c-cal.so
 %{_libdir}/cmake/aws-c-cal/aws-c-cal-config.cmake
 %{_libdir}/cmake/aws-c-cal/modules/FindLibCrypto.cmake
@@ -69,6 +73,9 @@ cryptography primitives
 
 
 %changelog
+* Tue Feb 22 2022 Kyle Knapp <kyleknap@amazon.com> - 0.5.12-5
+- Include missing devel directories
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.5.12-4
 - Move sha256_profile executable to standard package
 

--- a/specs/aws-c-compression.spec
+++ b/specs/aws-c-compression.spec
@@ -1,6 +1,6 @@
 Name:           aws-c-compression
 Version:        0.2.14
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Compression package for AWS SDK for C
 
 License:        ASL 2.0
@@ -54,8 +54,11 @@ compression algorithms such as gzip, and huffman encoding/decoding.
 %{_libdir}/libaws-c-compression.so.1.0.0
 
 %files devel
+%dir %{_includedir}/aws/compression
 %{_includedir}/aws/compression/*.h
 
+%dir %{_libdir}/cmake/aws-c-compression
+%dir %{_libdir}/cmake/aws-c-compression/shared
 %{_libdir}/libaws-c-compression.so
 %{_libdir}/cmake/aws-c-compression/aws-c-compression-config.cmake
 %{_libdir}/cmake/aws-c-compression/shared/aws-c-compression-targets-noconfig.cmake
@@ -63,6 +66,9 @@ compression algorithms such as gzip, and huffman encoding/decoding.
 
 
 %changelog
+* Tue Feb 22 2022 Kyle Knapp <kyleknap@amazon.com> - 0.2.14-4
+- Include missing devel directories
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.2.14-3
 - Update specfile based on review feedback
 

--- a/specs/aws-c-event-stream.spec
+++ b/specs/aws-c-event-stream.spec
@@ -1,6 +1,6 @@
 Name:           aws-c-event-stream
 Version:        0.2.7 
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        C99 implementation of the vnd.amazon.eventstream content-type
 
 License:        ASL 2.0
@@ -55,8 +55,11 @@ C99 implementation of the vnd.amazon.eventstream content-type
 %{_libdir}/libaws-c-event-stream.so.1.0.0
 
 %files devel
+%dir %{_includedir}/aws/event-stream
 %{_includedir}/aws/event-stream/*.h
 
+%dir %{_libdir}/cmake/aws-c-event-stream
+%dir %{_libdir}/cmake/aws-c-event-stream/shared
 %{_libdir}/libaws-c-event-stream.so
 %{_libdir}/cmake/aws-c-event-stream/aws-c-event-stream-config.cmake
 %{_libdir}/cmake/aws-c-event-stream/shared/aws-c-event-stream-targets-noconfig.cmake
@@ -64,6 +67,9 @@ C99 implementation of the vnd.amazon.eventstream content-type
 
 
 %changelog
+* Tue Feb 22 2022 Kyle Knapp <kyleknap@amazon.com> - 0.2.7-4
+- Include missing devel directories
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.2.7-3
 - Update specfile based on review feedback
 

--- a/specs/aws-c-http.spec
+++ b/specs/aws-c-http.spec
@@ -1,6 +1,6 @@
 Name:           aws-c-http
 Version:        0.6.8 
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        C99 implementation of the HTTP/1.1 and HTTP/2 specifications
 
 License:        ASL 2.0
@@ -59,8 +59,11 @@ C99 implementation of the HTTP/1.1 and HTTP/2 specifications
 %{_libdir}/libaws-c-http.so.1.0.0
 
 %files devel
+%dir %{_includedir}/aws/http
 %{_includedir}/aws/http/*.h
 
+%dir %{_libdir}/cmake/aws-c-http
+%dir %{_libdir}/cmake/aws-c-http/shared
 %{_libdir}/libaws-c-http.so
 %{_libdir}/cmake/aws-c-http/aws-c-http-config.cmake
 %{_libdir}/cmake/aws-c-http/shared/aws-c-http-targets-noconfig.cmake
@@ -68,6 +71,9 @@ C99 implementation of the HTTP/1.1 and HTTP/2 specifications
 
 
 %changelog
+* Tue Feb 22 2022 Kyle Knapp <kyleknap@amazon.com> - 0.6.8-5
+- Include missing devel directories
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.6.8-4
 - Move elasticurl executable to standard package
 

--- a/specs/aws-c-io.spec
+++ b/specs/aws-c-io.spec
@@ -1,6 +1,6 @@
 Name:           aws-c-io
 Version:        0.10.12 
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        IO package for AWS SDK for C
 
 License:        ASL 2.0
@@ -60,9 +60,13 @@ for application protocols.
 %{_libdir}/libaws-c-io.so.1.0.0
 
 %files devel
+%dir %{_includedir}/aws/io
+%dir %{_includedir}/aws/testing
 %{_includedir}/aws/io/*.h
 %{_includedir}/aws/testing/io_testing_channel.h
 
+%dir %{_libdir}/cmake/aws-c-io
+%dir %{_libdir}/cmake/aws-c-io/shared
 %{_libdir}/libaws-c-io.so
 %{_libdir}/cmake/aws-c-io/aws-c-io-config.cmake
 %{_libdir}/cmake/aws-c-io/shared/aws-c-io-targets-noconfig.cmake
@@ -70,6 +74,9 @@ for application protocols.
 
 
 %changelog
+* Tue Feb 22 2022 Kyle Knapp <kyleknap@amazon.com> - 0.10.12-4
+- Include missing devel directories
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.10.12-3
 - Update specfile based on review feedback
 

--- a/specs/aws-c-mqtt.spec
+++ b/specs/aws-c-mqtt.spec
@@ -1,6 +1,6 @@
 Name:           aws-c-mqtt
 Version:        0.7.8
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        C99 implementation of the MQTT 3.1.1 specification
 
 License:        ASL 2.0
@@ -65,9 +65,13 @@ C99 implementation of the MQTT 3.1.1 specification
 %{_libdir}/libaws-c-mqtt.so.1.0.0
 
 %files devel
+%dir %{_includedir}/aws/mqtt
+%dir %{_includedir}/aws/mqtt/private
 %{_includedir}/aws/mqtt/*.h
 %{_includedir}/aws/mqtt/private/mqtt_client_test_helper.h
 
+%dir %{_libdir}/cmake/aws-c-mqtt
+%dir %{_libdir}/cmake/aws-c-mqtt/shared
 %{_libdir}/libaws-c-mqtt.so
 %{_libdir}/cmake/aws-c-mqtt/aws-c-mqtt-config.cmake
 %{_libdir}/cmake/aws-c-mqtt/shared/aws-c-mqtt-targets-noconfig.cmake
@@ -76,6 +80,9 @@ C99 implementation of the MQTT 3.1.1 specification
 
 
 %changelog
+* Tue Feb 22 2022 Kyle Knapp <kyleknap@amazon.com> - 0.7.8-6
+- Include missing devel directories
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.7.8-5
 - Move elastipubsub executable to standard package
 

--- a/specs/aws-c-s3.spec
+++ b/specs/aws-c-s3.spec
@@ -1,6 +1,6 @@
 Name:           aws-c-s3
 Version:        0.1.27
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        C99 library implementation for communicating with the S3 service
 
 License:        ASL 2.0
@@ -66,8 +66,11 @@ designed for maximizing throughput on high bandwidth EC2 instances.
 %{_libdir}/libaws-c-s3.so.1.0.0
 
 %files devel
+%dir %{_includedir}/aws/s3
 %{_includedir}/aws/s3/*.h
 
+%dir %{_libdir}/cmake/aws-c-s3
+%dir %{_libdir}/cmake/aws-c-s3/shared
 %{_libdir}/libaws-c-s3.so
 %{_libdir}/cmake/aws-c-s3/aws-c-s3-config.cmake
 %{_libdir}/cmake/aws-c-s3/shared/aws-c-s3-targets-noconfig.cmake
@@ -76,6 +79,9 @@ designed for maximizing throughput on high bandwidth EC2 instances.
 
 
 %changelog
+* Tue Feb 22 2022 Kyle Knapp <kyleknap@amazon.com> - 0.1.27-4
+- Include missing devel directories
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.1.27-3
 - Update specfile based on review feedback
 

--- a/specs/aws-c-sdkutils.spec
+++ b/specs/aws-c-sdkutils.spec
@@ -1,6 +1,6 @@
 Name:           aws-c-sdkutils
 Version:        0.1.1 
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Utility package for AWS SDK for C
 
 License:        ASL 2.0
@@ -52,8 +52,11 @@ Utility package for AWS SDK for C
 %{_libdir}/libaws-c-sdkutils.so.1.0.0
 
 %files devel
+%dir %{_includedir}/aws/sdkutils
 %{_includedir}/aws/sdkutils/*.h
 
+%dir %{_libdir}/cmake/aws-c-sdkutils
+%dir %{_libdir}/cmake/aws-c-sdkutils/shared
 %{_libdir}/libaws-c-sdkutils.so
 %{_libdir}/cmake/aws-c-sdkutils/aws-c-sdkutils-config.cmake
 %{_libdir}/cmake/aws-c-sdkutils/shared/aws-c-sdkutils-targets-noconfig.cmake
@@ -61,6 +64,9 @@ Utility package for AWS SDK for C
 
 
 %changelog
+* Tue Feb 22 2022 Kyle Knapp <kyleknap@amazon.com> - 0.1.1-4
+- Include missing devel directories
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.1.1-3
 - Update specfile based on review feedback
 

--- a/specs/aws-checksums.spec
+++ b/specs/aws-checksums.spec
@@ -1,6 +1,6 @@
 Name:           aws-checksums
 Version:        0.1.12 
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Checksum package for AWS SDK for C
 
 License:        ASL 2.0
@@ -57,8 +57,11 @@ fallback to efficient SW implementations.
 %{_libdir}/libaws-checksums.so.1.0.0
 
 %files devel
+%dir %{_includedir}/aws/checksums
 %{_includedir}/aws/checksums/*.h
 
+%dir %{_libdir}/cmake/aws-checksums
+%dir %{_libdir}/cmake/aws-checksums/shared
 %{_libdir}/libaws-checksums.so
 %{_libdir}/cmake/aws-checksums/aws-checksums-config.cmake
 %{_libdir}/cmake/aws-checksums/shared/aws-checksums-targets-noconfig.cmake
@@ -66,6 +69,9 @@ fallback to efficient SW implementations.
 
 
 %changelog
+* Tue Feb 22 2022 Kyle Knapp <kyleknap@amazon.com> - 0.1.12-4
+- Include missing devel directories
+
 * Thu Feb 03 2022 Kyle Knapp <kyleknap@amazon.com> - 0.1.12-3
 - Update specfile based on review feedback
 


### PR DESCRIPTION
Fixes: https://github.com/davdunc/awscli-2-rpm/issues/45